### PR TITLE
Migrate reports somewhat successfully

### DIFF
--- a/application/dash_application/bamqc_gbovertime.py
+++ b/application/dash_application/bamqc_gbovertime.py
@@ -1,0 +1,100 @@
+import dash_html_components as html
+import dash_core_components as core
+from dash.dependencies import Input, Output
+from .dash_id import init_ids
+import pandas as pd
+import plotly.graph_objects as go 
+import gsiqcetl.load
+from gsiqcetl.bamqc.constants import CacheSchema
+from flask import current_app as app
+
+page_name = 'bamqc/gbovertime'
+
+ids = init_ids([
+    'lib', 
+    'month_plot',
+    '3month_plot',
+    'cum_plot'
+])
+
+bamqc = gsiqcetl.load.bamqc(CacheSchema.v1)
+col = gsiqcetl.load.bamqc_columns(CacheSchema.v1)
+
+COL_TOTAL_BASES = "total bases"
+COL_RUN_DATE = "run date"
+
+bamqc[COL_TOTAL_BASES] = bamqc[col.TotalReads] * bamqc[col.AverageReadLength]
+bamqc[COL_RUN_DATE] = pd.to_datetime(bamqc[col.Run].str[0:6], format="%y%m%d")
+
+bamqc_lib = [
+    {"label": x, "value": x} for x in bamqc[col.SequencingType].unique()
+]
+bamqc_lib.append({"label": "All", "value": "All"})
+
+layout = html.Div(
+    [
+        core.Dropdown(id=ids['lib'], options=bamqc_lib, value="All"),
+        core.Graph(id=ids['month_plot']),
+        core.Graph(id=ids['3month_plot']),
+        core.Graph(id=ids['cum_plot']),
+    ]
+)
+
+def init_callbacks(dash_app):
+    @dash_app.callback(
+        Output(ids['month_plot'], "figure"), 
+        [Input(ids['lib'], "value")])
+    @dash_app.server.cache.memoize(timeout=60)
+    def update_per_month(seq_type):
+        subset = filter_df(seq_type)
+
+        month_sum = subset.resample("MS", on=COL_RUN_DATE).sum()
+        trace = [go.Bar(x=month_sum.index, y=month_sum[COL_TOTAL_BASES] / 1e9)]
+        return {
+            "data": trace,
+            "layout": go.Layout(
+                title="GB per month", yaxis=dict(title="Gigabases")
+            ),
+        }
+
+    @dash_app.callback(
+        Output(ids['3month_plot'], "figure"), 
+        [Input(ids['lib'], "value")])
+    @dash_app.server.cache.memoize(timeout=60)
+    def update_per_3month(seq_type):
+        subset = filter_df(seq_type)
+        month_sum = subset.resample("3MS", on=COL_RUN_DATE).sum()
+        trace = [go.Bar(x=month_sum.index, y=month_sum[COL_TOTAL_BASES] / 1e9)]
+        return {
+            "data": trace,
+            "layout": go.Layout(
+                title="GB per 3 months", yaxis=dict(title="Gigabases")
+            ),
+        }
+
+    @dash_app.callback(
+        Output(ids['cum_plot'], "figure"), 
+        [Input(ids['lib'], "value")])
+    @dash_app.server.cache.memoize(timeout=60)
+    def update_cumulative(seq_type):
+        subset = filter_df(seq_type)
+        month_sum = subset.resample("MS", on=COL_RUN_DATE).sum()
+        month_cumsum = month_sum.cumsum()
+
+        trace = [
+            go.Scatter(x=month_cumsum.index, y=month_cumsum[COL_TOTAL_BASES] / 1e9)
+        ]
+
+        return {
+            "data": trace,
+            "layout": go.Layout(
+                title="Cumulative GB per month", yaxis=dict(title="Gigabases")
+            ),
+        }
+
+@app.cache.memoize(timeout=60)
+def filter_df(seq_type):
+    if seq_type == "All":
+        return bamqc
+    else:
+        return bamqc.loc[bamqc[col.SequencingType] == seq_type]

--- a/application/dash_application/bamqc_overtime.py
+++ b/application/dash_application/bamqc_overtime.py
@@ -1,0 +1,17 @@
+import dash_html_components as html
+import dash_core_components as core
+from dash.dependencies import Input, Output
+from .dash_id import init_ids
+
+TODO: this one
+
+page_name = 'bamqc/shiny'
+
+ids = init_ids([])
+
+## Dash layout object
+layout = html.Div(children='Placeholder') 
+
+## Please define all callbacks inside this procedure
+def init_callbacks(dash_app):
+

--- a/application/dash_application/bamqc_overtime.py
+++ b/application/dash_application/bamqc_overtime.py
@@ -2,16 +2,146 @@ import dash_html_components as html
 import dash_core_components as core
 from dash.dependencies import Input, Output
 from .dash_id import init_ids
-
-TODO: this one
+import pandas
+import gsiqcetl.load
+from gsiqcetl.bamqc.constants import CacheSchema
+from gsiqcetl.pinery.sampleprovenance.constants import (
+    CacheSchema as SampleProvenanceCacheSchema,
+)
+from application.dash_application.plots.shiny_mimic import ShinyMimic
 
 page_name = 'bamqc/shiny'
 
 ids = init_ids([])
 
-## Dash layout object
-layout = html.Div(children='Placeholder') 
+BAMQC_DF = gsiqcetl.load.bamqc(CacheSchema.v1)
+BAMQC_COL = gsiqcetl.load.bamqc_columns(CacheSchema.v1)
 
-## Please define all callbacks inside this procedure
+COL_RUN_DATE = "Run Date"
+PROJECT = "Project"
+FRACTION_ON_TARGET = "Read Fraction on Target"
+FRACTION_MAPPED = "Read Fraction Mapped"
+FRACTION_SECONDARY = "Read Fraction Secondary"
+
+# The Run Name is used to extract the date
+BAMQC_DF[COL_RUN_DATE] = (
+    BAMQC_DF[BAMQC_COL.Run].dropna().apply(lambda x: x.split("_")[0])
+)
+# Some runs do not have the proper format and will be excluded
+BAMQC_DF = BAMQC_DF[BAMQC_DF[COL_RUN_DATE].str.isnumeric()]
+BAMQC_DF[COL_RUN_DATE] = pandas.to_datetime(
+    BAMQC_DF[COL_RUN_DATE], yearfirst=True
+)
+
+BAMQC_DF[PROJECT] = BAMQC_DF[BAMQC_COL.Library].apply(lambda x: x.split("_")[0])
+
+BAMQC_DF[FRACTION_ON_TARGET] = (
+    BAMQC_DF[BAMQC_COL.ReadsOnTarget] / BAMQC_DF[BAMQC_COL.TotalReads]
+)
+BAMQC_DF[FRACTION_MAPPED] = (
+    BAMQC_DF[BAMQC_COL.MappedReads] / BAMQC_DF[BAMQC_COL.TotalReads]
+)
+BAMQC_DF[FRACTION_SECONDARY] = (
+    BAMQC_DF[BAMQC_COL.NonPrimaryReads] / BAMQC_DF[BAMQC_COL.TotalReads]
+)
+
+# Pull in meta data from Pinery
+# noinspection PyTypeChecker
+PINERY: pandas.DataFrame = gsiqcetl.load.pinery_sample_provenance(
+    SampleProvenanceCacheSchema.v1
+)
+PINERY_COL = gsiqcetl.load.pinery_sample_provenance_columns(
+    SampleProvenanceCacheSchema.v1
+)
+
+PINERY = PINERY[
+    [
+        PINERY_COL.SampleName,
+        PINERY_COL.SequencerRunName,
+        PINERY_COL.LaneNumber,
+        PINERY_COL.PrepKit,
+        PINERY_COL.LibrarySourceTemplateType,
+        PINERY_COL.TissueOrigin,
+        PINERY_COL.TissueType,
+        PINERY_COL.TissuePreparation,
+    ]
+]
+
+BAMQC_DF = BAMQC_DF.merge(
+    PINERY,
+    how="left",
+    left_on=[BAMQC_COL.Library, BAMQC_COL.Run, BAMQC_COL.Lane],
+    right_on=[
+        PINERY_COL.SampleName,
+        PINERY_COL.SequencerRunName,
+        PINERY_COL.LaneNumber,
+    ],
+)
+
+# NaN kits need to be changed to a str. Use the existing Unspecified
+BAMQC_DF = BAMQC_DF.fillna({PINERY_COL.PrepKit: "Unspecified"})
+BAMQC_DF = BAMQC_DF.fillna({PINERY_COL.LibrarySourceTemplateType: "Unknown"})
+# NaN Tissue Origin is set to `nn`, which is used by MISO for unknown
+BAMQC_DF = BAMQC_DF.fillna({PINERY_COL.TissueOrigin: "nn"})
+# NaN Tissue Type is set to `n`, which is used by MISO for unknown
+BAMQC_DF = BAMQC_DF.fillna({PINERY_COL.TissueType: "n"})
+BAMQC_DF = BAMQC_DF.fillna({PINERY_COL.TissuePreparation: "Unknown"})
+
+# Which metrics can be plotted
+METRICS_TO_GRAPH = (
+    FRACTION_ON_TARGET,
+    FRACTION_MAPPED,
+    BAMQC_COL.InsertMean,
+    BAMQC_COL.ReadsPerStartPoint,
+    BAMQC_COL.TotalReads,
+    FRACTION_SECONDARY,
+)
+
+
+# Which columns will the data table always have
+DEFAULT_TABLE_COLUMN = [
+    {"name": "Library", "id": BAMQC_COL.Library},
+    {"name": "Project", "id": PROJECT},
+    {"name": "Run", "id": BAMQC_COL.Run},
+    {"name": "Lane", "id": BAMQC_COL.Lane},
+    {"name": "Kit", "id": PINERY_COL.PrepKit},
+    {"name": "Library Design", "id": PINERY_COL.LibrarySourceTemplateType},
+    {"name": "Tissue Origin", "id": PINERY_COL.TissueOrigin},
+    {"name": "Tissue Type", "id": PINERY_COL.TissueType},
+    {"name": "Tissue Material", "id": PINERY_COL.TissuePreparation},
+]
+
+# Columns on which shape and colour can be set
+SHAPE_COLOUR_COLUMN = [
+    {"name": "Project", "id": PROJECT},
+    {"name": "Kit", "id": PINERY_COL.PrepKit},
+    {"name": "Library Design", "id": PINERY_COL.LibrarySourceTemplateType},
+    {"name": "Tissue Origin", "id": PINERY_COL.TissueOrigin},
+    {"name": "Tissue Type", "id": PINERY_COL.TissueType},
+    {"name": "Tissue Material", "id": PINERY_COL.TissuePreparation},
+]
+
+
+plot_creator = ShinyMimic(
+    lambda: BAMQC_DF,
+    "bamqc_over_time",
+    METRICS_TO_GRAPH,
+    SHAPE_COLOUR_COLUMN,
+    SHAPE_COLOUR_COLUMN,
+    PROJECT,
+    PINERY_COL.PrepKit,
+    COL_RUN_DATE,
+    BAMQC_COL.Library,
+)
+
+
+layout = plot_creator.generate_layout(
+    4,
+    PROJECT,
+    PINERY_COL.PrepKit,
+    DEFAULT_TABLE_COLUMN + [{"name": i, "id": i} for i in METRICS_TO_GRAPH],
+)
+
 def init_callbacks(dash_app):
+    plot_creator.assign_callbacks(dash_app)
 

--- a/application/dash_application/bamqc_overtime.py
+++ b/application/dash_application/bamqc_overtime.py
@@ -6,7 +6,7 @@ import pandas
 import gsiqcetl.load
 from gsiqcetl.bamqc.constants import CacheSchema
 from gsiqcetl.pinery.sampleprovenance.constants import (
-    CacheSchema as SampleProvenanceCacheSchema,
+    CacheSchema as SampleProvenanceCacheSchema
 )
 from application.dash_application.plots.shiny_mimic import ShinyMimic
 

--- a/application/dash_application/bcl2fastq.py
+++ b/application/dash_application/bcl2fastq.py
@@ -3,12 +3,11 @@ import dash_core_components as core
 from dash.dependencies import Input, Output
 from .dash_id import init_ids
 from flask import current_app as app
-
 import gsiqcetl.load
 from gsiqcetl.bcl2fastq.constants import SamplesSchema, UnknownIndexSchema
 import gsiqcetl.bcl2fastq.utility
+import urllib.parse
 
-#TODO: there was a rewrite of this
 
 page_name = 'bcl2fastq/indexinfo'
 
@@ -32,6 +31,15 @@ all_runs = index[index_col.Run].sort_values(ascending=False).unique()
 
 COL_LIBRARY = "library"
 COL_INDEX = "index"
+
+""" Sample_run_hidden holds json split format of "Known" columns:
+"FlowCell","Index1","Index2","LIMS IUS SWID","LaneClusterPF","LaneClusterRaw",
+"LaneNumber","LaneYield","QualityScoreSum","ReadNumber","Run","RunNumber","SampleID",
+"SampleName","SampleNumberReads","SampleYield","TrimmedBases","Yield","YieldQ30"
+
+ pruned_unknown_hidden holds json split format of "unknown" columns:
+ "Count","LaneNumber","Index1","Index2","Run","LIMS IUS SWID
+ """
 
 layout = html.Div(
     children=[
@@ -86,13 +94,12 @@ layout = html.Div(
     ]
 )
 
-
 def init_callbacks(dash_app):
     dash_app.config.suppress_callback_exceptions = True
 
     @dash_app.callback(
         [Output(ids['run_select'], "value"), 
-        Output("error", "displayed")],
+        Output(ids['error'], "displayed")],
         [Input(ids['bcl2fastq_url'], "pathname")],
     )
     @dash_app.server.cache.memoize(timeout=60)
@@ -126,18 +133,23 @@ def init_callbacks(dash_app):
     )
     @dash_app.server.cache.memoize(timeout=60)
     def update_layout(run_alias):
-        """ When input(run dropdown) is changed, known index bar, unknown index bar, piechart and textarea are updated
-            Parameter:
-                run_alias: user-selected run name from dropdown
-            Returns:
-                functions update_known_index_bar, update_unknown_index_bar, update_pie_chart's data value,
-                and update_pie_chart's fraction value
+        """
+        When input(run dropdown) is changed, known index bar, unknown index bar,
+        piechart and textarea are updated
+
+        Parameter:
+            run_alias: user-selected run name from dropdown
+        Returns:
+            functions update_known_index_bar, update_unknown_index_bar,
+            update_pie_chart's data value, and update_pie_chart's fraction value
         """
 
         run = index[index[index_col.Run] == run_alias]
         run = run[run[index_col.ReadNumber] == 1]
         run = run[~run[index_col.SampleID].isna()]
         run = run.drop_duplicates([index_col.SampleID, index_col.LaneNumber])
+        # TODO: Replace with join from Pinery (on Run, Lane, Index1, Index2)
+        #  10X index (SI-GA-H11) will have to be converted to nucleotide
         run[COL_LIBRARY] = run[index_col.SampleID].str.extract(
             r"SWID_\d+_(\w+_\d+_.*_\d+_[A-Z]{2})_"
         )
@@ -158,16 +170,96 @@ def init_callbacks(dash_app):
             run_alias, index
         )
 
-        pie_data, textarea_fraction = create_pie_chart(run, pruned, total_clusters)
+        pie_data, textarea_fraction = create_pie_chart(
+            run, pruned, total_clusters
+        )
 
         return (
             create_known_index_bar(run),
             create_unknown_index_bar(pruned),
             pie_data,
-            textarea_fraction,
+            textarea_fraction
         )
 
-## These aren't in init_callbacks. Do they need to be? Are we OK to call them?
+@app.cache.memoize(timeout=60)
+def generate_layout(qs) -> html.Div:
+    """
+    Within the main layout division there are 3 groups:
+    1. Top: Bar graphs showing each known index count
+    2. Bottom left: Pie chart and text box
+        a) Pie chart shows proportion of known and unknown indices
+        b) Text box measures how well multiple analyses were combined (see
+            below)
+    3. Bottom right: Bar graph breaking down count of each unknown index
+
+    In many instances, multiple bcl2fastq analyses are performed for one run. It
+    is necessary to combine them to obtain meaningful statistics of unknown
+    indices, but due to one run combining single/dual and different length
+    indices, the calculations do have to make certain assumptions. The ratio
+    displayed in the text box is of the calculated read count divided by the
+    machine produced read count.
+
+    Args:
+        qs: The query string from the URL that modifying the layout.
+            "run" parameter sets the run selected on layout load
+
+    Returns: The Div of the complete layout with the defaults set from the
+        passed query string
+
+    """
+
+    # If query string exist, Dash returns it with the leading `?`
+    # The `parse_qs` function does not expect this and `?` needs to be removed
+    if qs:
+        qs = qs[1:]
+
+    qs = urllib.parse.parse_qs(qs)
+
+    if "run" in qs and qs["run"][0] in all_runs:
+        default_run = qs["run"][0]
+    else:
+        default_run = all_runs[0]
+
+    return html.Div(
+        children=[
+            core.Dropdown(
+                id=ids['run_select'],
+                #   Options is concantenated string versions of all_runs.
+                options=[{"label": r, "value": r} for r in all_runs],
+                value=default_run,
+                clearable=False,
+            ),
+            core.Graph(id=ids['known_index_bar']),
+            html.Div(
+                [
+                    html.Div(
+                        [
+                            core.Graph(id=ids['known_unknown_pie']),
+                            core.Textarea(
+                                id=ids['known_fraction'],
+                                style={"width": "100%"},
+                                readOnly=True,
+                                # This is hover text
+                                title="Assumptions are made about which indexes"
+                                " are known or unknown. This is due to "
+                                "multiple bcl2fastq analyses being used "
+                                "on one run. This number should be 100%.",
+                            ),
+                        ],
+                        style={"width": "25%", "display": "inline-block"},
+                    ),
+                    html.Div(
+                        [core.Graph(id=ids['unknown_index_bar'])],
+                        style={
+                            "width": "75%",
+                            "display": "inline-block",
+                            "float": "right",
+                        },
+                    ),
+                ]
+            ),
+        ]
+    )
 
 @app.cache.memoize(timeout=60)
 def create_known_index_bar(run):

--- a/application/dash_application/bcl2fastq.py
+++ b/application/dash_application/bcl2fastq.py
@@ -8,6 +8,8 @@ import gsiqcetl.load
 from gsiqcetl.bcl2fastq.constants import SamplesSchema, UnknownIndexSchema
 import gsiqcetl.bcl2fastq.utility
 
+#TODO: there was a rewrite of this
+
 page_name = 'bcl2fastq/indexinfo'
 
 ids = init_ids([

--- a/application/dash_application/pages.py
+++ b/application/dash_application/pages.py
@@ -8,7 +8,9 @@ pagenames = [
     'bcl2fastq',
     'url_handler',
     'bamqc_gbovertime',
-    'runreport'
+    'runreport',
+    'runscanner',
+    'bamqc_overtime'
 ]
 
 # Please do not edit this array

--- a/application/dash_application/pages.py
+++ b/application/dash_application/pages.py
@@ -6,7 +6,8 @@ prefix = 'application.dash_application.'
 # e.g., pagenames = ['myPage', 'myPage2']
 pagenames = [
     'bcl2fastq',
-    'url_handler'
+    'url_handler',
+    'bamqc_gbovertime'
 ]
 
 # Please do not edit this array

--- a/application/dash_application/pages.py
+++ b/application/dash_application/pages.py
@@ -7,7 +7,8 @@ prefix = 'application.dash_application.'
 pagenames = [
     'bcl2fastq',
     'url_handler',
-    'bamqc_gbovertime'
+    'bamqc_gbovertime',
+    'runreport'
 ]
 
 # Please do not edit this array

--- a/application/dash_application/pages.py
+++ b/application/dash_application/pages.py
@@ -11,7 +11,8 @@ pagenames = [
     'runreport',
     'runscanner',
     'bamqc_overtime',
-    'rnaseqc'
+    'rnaseqc',
+    'poolqc'
 ]
 
 # Please do not edit this array

--- a/application/dash_application/pages.py
+++ b/application/dash_application/pages.py
@@ -10,7 +10,8 @@ pagenames = [
     'bamqc_gbovertime',
     'runreport',
     'runscanner',
-    'bamqc_overtime'
+    'bamqc_overtime',
+    'rnaseqc'
 ]
 
 # Please do not edit this array

--- a/application/dash_application/plots/plot_scatter_subplot.py
+++ b/application/dash_application/plots/plot_scatter_subplot.py
@@ -1,0 +1,250 @@
+import pandas
+import plotly.subplots
+import plotly.graph_objects
+
+import collections
+import itertools
+
+# A convenience container that links how a metric should be graphed
+# The name is the column name
+# The properties is a dict
+# The dict key is a value found in the column
+# The dict value is the property (color, shape, etc) assigned to the dict keY
+PlotProperty = collections.namedtuple("PlotProperty", ["name", "properties"])
+
+
+def assign_consistent_property(values: list, prop: list) -> dict:
+    """
+    Entries in the DataFrame column (project, tissue, kit) need to be assigned
+    consistent properties (color, shape) across all plots. This does is fairly
+    simply, by looping in order through each unique column entry and assigning
+    them the next available property. Property lists cannot run out, as it loops
+    back to the beginning.
+
+    Args:
+        values: The column entries. Need to be unique.
+        prop: The plotting properties to assign to each entry
+
+    Returns: A dictionary with keys being the unique DataFrame column entries
+        and the dictionary values being the plotting properties (color, shape).
+
+    """
+    result = {}
+    prop = itertools.cycle(prop)
+
+    for v in values:
+        result[v] = next(prop)
+
+    return result
+
+
+def create_plot_dict(
+    df: pandas.DataFrame,
+    variable: str,
+    date_column_name: str,
+    library_column_name: str,
+    color: PlotProperty,
+    shape: PlotProperty,
+    order: bool,
+    show_legend: bool = False,
+) -> list:
+    """
+    Creates the traces for a given column in the DataFrame, assigning each
+    point shape and color.
+
+    Args:
+        df: DataFrame that contains the data
+        variable: Which column to plot on the Y-axis
+        date_column_name: Which column contains the dates
+        library_column_name: Which column contains library names
+        color: What color to assign to each data point
+        shape: What shape to assign to each data point
+        order: If true, plot the points in the order given. Otherwise, plot
+            by date
+        show_legend: Should the trace have a legend displayed
+
+    Returns:
+        Plotly compliant list of traces to plot
+
+    """
+    result = []
+
+    if order:
+        df["x_axis"] = list(range(0, len(df)))
+    else:
+        df["x_axis"] = list(df[date_column_name])
+
+    for g in df.groupby([color.name, shape.name]):
+        color_name = g[0][0]
+        shape_name = g[0][1]
+        data = g[1]
+
+        data_shape = data[shape.name].apply(lambda x: shape.properties[x])
+
+        p = {
+            "x": list(data["x_axis"]),
+            "y": list(data[variable]),
+            "type": "scattergl",
+            "mode": "markers",
+            "name": color_name + "<br>" + shape_name,
+            "text": list(data[library_column_name]),
+            "legendgroup": color_name,
+            "showlegend": show_legend,
+            "marker": {
+                "color": color.properties[color_name],
+                "symbol": data_shape,
+            },
+            # Hover labels are not cropped
+            # https://github.com/plotly/plotly.js/issues/460
+            "hoverlabel": {"namelength": -1},
+        }
+
+        result.append(p)
+
+    return result
+
+
+def create_subplot(
+    rna_df: pandas.DataFrame,
+    graph_list: list,
+    date_column_name: str,
+    library_column_name: str,
+    color_col: str,
+    shape_col: str,
+    order: bool,
+) -> plotly.graph_objects.Figure:
+    """
+    Creates the subplots for the columns provided
+
+    Args:
+        rna_df: DataFrame containing the data
+        graph_list: Which columns to plot
+        date_column_name: Which column contains the dates
+        library_column_name: Which column contains library names
+        color_col: Which column should specify the colors in the plot
+        shape_col: Which column should specify the shapes in the plot
+        order: If True, points will be plotted in their DataFrame order (0 to
+            n - 1). Otherwise, plotted by date.
+
+    Returns: The plotly figure that can be displayed
+
+    Raises:
+        ValueError: If more than 8 columns are given. Up to 8 subplots are
+        supported.
+
+    """
+    if len(graph_list) > 8:
+        raise ValueError("Can only plot up to 8 subplots")
+
+    traces = []
+
+    # Sort irrespective of capital letters
+    color_names = sorted(rna_df[color_col].unique(), key=lambda x: x.upper())
+    colors = assign_consistent_property(color_names, COLOURS)
+    color_prop = PlotProperty(color_col, colors)
+
+    # Sort irrespective of capital letters
+    shape_names = sorted(rna_df[shape_col].unique(), key=lambda x: x.upper())
+    shapes = assign_consistent_property(shape_names, SHAPES)
+    shape_prop = PlotProperty(shape_col, shapes)
+
+    for g in graph_list:
+        if len(traces) == 0:
+            traces.append(
+                create_plot_dict(
+                    rna_df,
+                    g,
+                    date_column_name,
+                    library_column_name,
+                    color_prop,
+                    shape_prop,
+                    order,
+                    show_legend=True,
+                )
+            )
+        else:
+            traces.append(
+                create_plot_dict(
+                    rna_df,
+                    g,
+                    date_column_name,
+                    library_column_name,
+                    color_prop,
+                    shape_prop,
+                    order,
+                    show_legend=False,
+                )
+            )
+
+    # Hardcoded subplot positions (starting from top left and going across)
+    rows = [1, 2, 3, 4, 5, 6, 7, 8][: len(traces)]
+    cols = [1, 1, 1, 1, 1, 1, 1, 1][: len(traces)]
+    max_rows = max(rows)
+
+    # Each row in the DataFrame is plotted across all subplots
+    # The other approach would be to plot each column in only one subplot
+    traces = zip(*traces)
+
+    fig = plotly.subplots.make_subplots(
+        rows=max_rows,
+        cols=1,
+        subplot_titles=graph_list,
+        print_grid=False,
+        shared_xaxes=True,
+    )
+
+    # Go across each row and put each data point in the respective subplot
+    for t in traces:
+        fig.add_traces(t, rows=rows, cols=cols)
+
+    fig.update_layout(height=400 * max_rows, template="plotly_white")
+
+    # If the data is sorted, the x-axis will be increasing numbers. Hide them
+    fig.update_xaxes(showticklabels=not order)
+
+    # If you want legend at the bottom
+    # fig['layout']['legend'].update(orientation="h")
+
+    return fig
+
+
+# The colours that are used in the graphs
+COLOURS = [
+    "#1f77b4",
+    "#aec7e8",
+    "#ff7f0e",
+    "#ffbb78",
+    "#2ca02c",
+    "#98df8a",
+    "#d62728",
+    "#ff9896",
+    "#9467bd",
+    "#c5b0d5",
+    "#8c564b",
+    "#c49c94",
+    "#e377c2",
+    "#f7b6d2",
+    "#7f7f7f",
+    "#c7c7c7",
+    "#bcbd22",
+    "#dbdb8d",
+    "#17becf",
+    "#9edae5",
+]
+
+# The shapes of the points to use in the graph
+# More can be added if the future needs it
+# See https://plot.ly/python/reference/#scatter-marker
+SHAPES = [
+    "circle",
+    "square",
+    "diamond",
+    "cross",
+    "x",
+    "triangle-up",
+    "triangle-down",
+    "triangle-left",
+    "triangle-right",
+    "pentagon",
+    "star",
+]

--- a/application/dash_application/plots/shiny_mimic.py
+++ b/application/dash_application/plots/shiny_mimic.py
@@ -11,7 +11,6 @@ from dash.dependencies import Output, Input, State
 import dash.exceptions
 import dash_table
 import dash
-import pdb
 
 from application.dash_application.plots.plot_scatter_subplot import create_subplot
 
@@ -219,7 +218,6 @@ class ShinyMimic:
             Returns: The incremented click number
 
             """
-            pdb.set_trace()
             n_clicks = 0 if n_clicks is None else n_clicks + 1
             return n_clicks
 
@@ -254,7 +252,6 @@ class ShinyMimic:
             Returns: The data to put in the data table
 
             """
-            pdb.set_trace()
             if drawer_open:
                 raise dash.exceptions.PreventUpdate(
                     "Drawer opening does not require recalculation"
@@ -317,7 +314,6 @@ class ShinyMimic:
             Returns: The figures to plot
 
             """
-            pdb.set_trace()
             to_plot = pandas.DataFrame(data_to_plot)
 
             # The variable can be None or an empty list when no sorting is done
@@ -352,7 +348,6 @@ class ShinyMimic:
 
             """
             # Do no open if the button has never been clicked, otherwise open
-            pdb.set_trace()
             return n_clicks is not None
 
     def generate_main_window(

--- a/application/dash_application/plots/shiny_mimic.py
+++ b/application/dash_application/plots/shiny_mimic.py
@@ -11,6 +11,7 @@ from dash.dependencies import Output, Input, State
 import dash.exceptions
 import dash_table
 import dash
+import pdb
 
 from application.dash_application.plots.plot_scatter_subplot import create_subplot
 
@@ -218,6 +219,7 @@ class ShinyMimic:
             Returns: The incremented click number
 
             """
+            pdb.set_trace()
             n_clicks = 0 if n_clicks is None else n_clicks + 1
             return n_clicks
 
@@ -252,6 +254,7 @@ class ShinyMimic:
             Returns: The data to put in the data table
 
             """
+            pdb.set_trace()
             if drawer_open:
                 raise dash.exceptions.PreventUpdate(
                     "Drawer opening does not require recalculation"
@@ -314,6 +317,7 @@ class ShinyMimic:
             Returns: The figures to plot
 
             """
+            pdb.set_trace()
             to_plot = pandas.DataFrame(data_to_plot)
 
             # The variable can be None or an empty list when no sorting is done
@@ -348,6 +352,7 @@ class ShinyMimic:
 
             """
             # Do no open if the button has never been clicked, otherwise open
+            pdb.set_trace()
             return n_clicks is not None
 
     def generate_main_window(

--- a/application/dash_application/plots/shiny_mimic.py
+++ b/application/dash_application/plots/shiny_mimic.py
@@ -1,0 +1,456 @@
+from typing import List, Dict, Callable, Union
+
+import pandas
+from pandas import DataFrame
+
+import sd_material_ui
+
+import dash_html_components as html
+import dash_core_components as core
+from dash.dependencies import Output, Input, State
+import dash.exceptions
+import dash_table
+import dash
+
+from application.dash_application.plots.plot_scatter_subplot import create_subplot
+
+
+class ShinyMimic:
+    ID_BUTTON_OPTIONS = "options_button"
+    ID_BUTTON_UPDATE = "update_button"
+    ID_DATA_TABLE = "data_table"
+    ID_DATE_PICKER = "date_picker"
+    ID_DRAWER = "project_drawer"
+    ID_LOADER_DATATABLE = "datatable_loader"
+    ID_LOADER_GRAPH = "graph_loader"
+    ID_MULTISELECT_KIT = "kit_multi_select"
+    ID_MULTISELECT_PLOTS = "plots_multi_select"
+    ID_MULTISELECT_PROJECT = "project_multi_select"
+    ID_PLOT = "plot"
+    ID_SELECT_COLOUR = "colour_by"
+    ID_SELECT_SHAPE = "shape_by"
+
+    def __init__(
+        self,
+        df: Callable[[], DataFrame],
+        id_prefix: str,
+        columns_to_plot: List[str],
+        colour_columns: List[Dict[str, str]],
+        shape_columns: List[Dict[str, str]],
+        project_column_name: str,
+        kit_column_name: str,
+        date_column_name: str,
+        library_column_name: str,
+    ):
+        self.df_func = df
+        self.id_prefix = id_prefix
+        self.columns_to_plot = columns_to_plot
+        self.colour_columns = colour_columns
+        self.shape_columns = shape_columns
+        self.project_column_name = project_column_name
+        self.kit_column_name = kit_column_name
+        self.date_column_name = date_column_name
+        self.library_column_name = library_column_name
+
+    def get_sorted_column(self, column_name) -> list:
+        return list(self.df_func()[column_name].sort_values().unique())
+
+    def generate_id(self, name: str):
+        return f"{self.id_prefix}_{name}"
+
+    def generate_layout(
+        self,
+        n_plot_at_startup: int,
+        default_colour_column: str,
+        default_shape_column: str,
+        data_table_columns: List[Dict[str, str]],
+    ) -> html.Div:
+        return html.Div(
+            children=[
+                self.generate_drawer_layout(
+                    n_plot_at_startup,
+                    default_colour_column,
+                    default_shape_column,
+                ),
+                self.generate_main_window(data_table_columns),
+            ]
+        )
+
+    def generate_drawer_layout(
+        self,
+        n_plot_at_startup: int,
+        default_colour_column: str,
+        default_shape_column: str,
+    ) -> sd_material_ui.Drawer:
+        return sd_material_ui.Drawer(
+            id=self.id_drawer,
+            open=False,
+            docked=False,
+            width="50%",
+            children=[
+                html.Div(
+                    children=[
+                        html.Label("Project:"),
+                        core.Dropdown(
+                            id=self.id_multiselect_project,
+                            multi=True,
+                            options=[
+                                {"label": x, "value": x}
+                                for x in self.get_sorted_column(
+                                    self.project_column_name
+                                )
+                            ],
+                            value=self.get_sorted_column(
+                                self.project_column_name
+                            ),
+                        ),
+                        html.Br(),
+                        html.Label("Kits:"),
+                        core.Dropdown(
+                            id=self.id_multiselect_kit,
+                            multi=True,
+                            options=[
+                                {"label": x, "value": x}
+                                for x in self.get_sorted_column(
+                                    self.kit_column_name
+                                )
+                            ],
+                            value=self.get_sorted_column(self.kit_column_name),
+                        ),
+                        html.Br(),
+                        html.Label("Dates: "),
+                        core.DatePickerRange(
+                            id=self.id_date_picker,
+                            display_format="YYYY-MM-DD",
+                            min_date_allowed=min(
+                                self.df_func()[self.date_column_name]
+                            ),
+                            max_date_allowed=max(
+                                self.df_func()[self.date_column_name]
+                            ),
+                            start_date=min(
+                                self.df_func()[self.date_column_name]
+                            ),
+                            end_date=max(self.df_func()[self.date_column_name]),
+                        ),
+                        html.Br(),
+                        html.Br(),
+                        html.Label("Show Graphs:"),
+                        core.Dropdown(
+                            id=self.id_multiselect_plots,
+                            multi=True,
+                            options=[
+                                {"label": x, "value": x}
+                                for x in self.columns_to_plot
+                            ],
+                            value=self.columns_to_plot[:n_plot_at_startup],
+                        ),
+                        html.Br(),
+                        html.Div(
+                            [
+                                html.Div(
+                                    [
+                                        html.Label("Colour by:"),
+                                        core.Dropdown(
+                                            id=self.id_select_colour,
+                                            options=[
+                                                {
+                                                    "label": x["name"],
+                                                    "value": x["id"],
+                                                }
+                                                for x in self.colour_columns
+                                            ],
+                                            value=default_colour_column,
+                                        ),
+                                    ],
+                                    style={
+                                        "width": "45%",
+                                        "display": "inline-block",
+                                    },
+                                ),
+                                html.Div(
+                                    [
+                                        html.Label("Shape by:"),
+                                        core.Dropdown(
+                                            id=self.id_select_shape,
+                                            options=[
+                                                {
+                                                    "label": x["name"],
+                                                    "value": x["id"],
+                                                }
+                                                for x in self.shape_columns
+                                            ],
+                                            value=default_shape_column,
+                                        ),
+                                    ],
+                                    style={
+                                        "width": "45%",
+                                        "display": "inline-block",
+                                        "float": "right",
+                                    },
+                                ),
+                            ]
+                        ),
+                    ],
+                    style={"margin": "23px"},
+                )
+            ],
+        )
+
+    def assign_callbacks(self, app: dash.Dash):
+        @app.callback(
+            Output(self.id_button_update, "n_clicks"),
+            [Input(self.id_data_table, "data")],
+            [State(self.id_button_update, "n_clicks")],
+        )
+        def click_update_graph_button(_data, n_clicks):
+            """ A programmatic way to click the button when the data_table data
+            changes, which causes the graphs to be rendered.
+
+            This function is necessary because rendering the graphs when the
+            data_table data changes does not work. See the rendering function
+            for more details.
+
+            Args:
+                _data: Causes the button to be clicked, but not used
+                n_clicks: The previous number of clicks on the button
+
+            Returns: The incremented click number
+
+            """
+            n_clicks = 0 if n_clicks is None else n_clicks + 1
+            return n_clicks
+
+        @app.callback(
+            Output(self.id_data_table, "data"),
+            [Input(self.id_drawer, "open")],
+            [
+                State(self.id_multiselect_project, "value"),
+                State(self.id_multiselect_kit, "value"),
+                State(self.id_date_picker, "start_date"),
+                State(self.id_date_picker, "end_date"),
+            ],
+        )
+        def populate_data_table(
+            drawer_open: bool,
+            projects: List[str],
+            kits: List[str],
+            start_date: str,
+            end_date: str,
+        ):
+            """
+            Given the filtering options in the side drawer, create the data
+            table with the filtered data.
+
+            Args:
+                drawer_open: Has the drawer been opened (False is it was closed)
+                projects: Which projects to plot
+                kits: Which kits to plot
+                start_date: From which date to display (inclusive)
+                end_date: Up to which date to display (inclusive)
+
+            Returns: The data to put in the data table
+
+            """
+            if drawer_open:
+                raise dash.exceptions.PreventUpdate(
+                    "Drawer opening does not require recalculation"
+                )
+
+            to_table = self.df_func()[
+                self.df_func()[self.project_column_name].isin(projects)
+            ]
+            to_table = to_table[to_table[self.kit_column_name].isin(kits)]
+            to_table = to_table[
+                to_table[self.date_column_name]
+                >= pandas.to_datetime(start_date)
+            ]
+            to_table = to_table[
+                to_table[self.date_column_name] <= pandas.to_datetime(end_date)
+            ]
+
+            return to_table.to_dict("records")
+
+        @app.callback(
+            Output(self.id_plot, "figure"),
+            [Input(self.id_button_update, "n_clicks")],
+            [
+                State(self.id_data_table, "derived_virtual_data"),
+                State(self.id_multiselect_plots, "value"),
+                State(self.id_select_colour, "value"),
+                State(self.id_select_shape, "value"),
+                State(self.id_data_table, "sort_by"),
+            ],
+        )
+        def graph_subplot(
+            _clicks: int,
+            data_to_plot: list,
+            graphs: List[str],
+            colour_by: str,
+            shape_by: str,
+            sort_by: Union[None, list],
+        ):
+            """
+            Plots the data from the data table, preserving all sorting and
+            filtering applied.
+
+            The button that fires this callback had to be used. The simpler
+            option would have been to fire it when the data table body is
+            updated, but the `derived_virtual_data` property was linked to the
+            body data and was not updated fast enough
+
+            Args:
+                _clicks: The click fires the callback, but is never used
+                data_to_plot: This is the sorted and filtered data table data,
+                    which will be used for plots
+                graphs: Which columns to plot
+                colour_by: The column that determines data colour
+                shape_by: The column that determines data shape
+                sort_by: The columns on which data is sorted. The content does
+                    not matter for this function. If there is anything in this
+                    variable, the data will be plotted in order it is found in
+                    the input DataFrame
+
+            Returns: The figures to plot
+
+            """
+            to_plot = pandas.DataFrame(data_to_plot)
+
+            # The variable can be None or an empty list when no sorting is done
+            order = True if sort_by else False
+
+            if len(to_plot) > 0:
+                return create_subplot(
+                    to_plot,
+                    graphs,
+                    self.date_column_name,
+                    self.library_column_name,
+                    colour_by,
+                    shape_by,
+                    order,
+                )
+            else:
+                return {}
+
+        @app.callback(
+            Output(self.id_drawer, "open"),
+            [Input(self.id_button_options, "n_clicks")],
+        )
+        def open_project_drawer(n_clicks: Union[int, None]) -> bool:
+            """
+            Open the drawer when the Open Drawer button is clicked
+
+            Args:
+                n_clicks: How often has the button been clicked. None if it has
+                    never been clicked
+
+            Returns: Should the drawer be opened
+
+            """
+            # Do no open if the button has never been clicked, otherwise open
+            return n_clicks is not None
+
+    def generate_main_window(
+        self, data_table_columns: List[Dict[str, str]]
+    ) -> html.Div:
+        return html.Div(
+            children=[
+                html.Div(
+                    [
+                        html.Div(
+                            sd_material_ui.RaisedButton(
+                                id=self.id_button_options, label="Options"
+                            ),
+                            style={"display": "inline-block"},
+                        ),
+                        html.Div(
+                            sd_material_ui.RaisedButton(
+                                id=self.id_button_update, label="Update Graphs"
+                            ),
+                            style={
+                                "display": "inline-block",
+                                "margin-left": "15px",
+                            },
+                        ),
+                    ],
+                    style={"margin-bottom": "5px"},
+                ),
+                core.Loading(
+                    id=self.id_loader_graph,
+                    children=[
+                        sd_material_ui.Paper([core.Graph(id=self.id_plot)])
+                    ],
+                ),
+                core.Loading(
+                    id=self.id_loader_data_table,
+                    children=[
+                        sd_material_ui.Paper(
+                            [
+                                dash_table.DataTable(
+                                    id=self.id_data_table,
+                                    columns=data_table_columns,
+                                    data=self.df_func().to_dict("records"),
+                                    page_size=50,
+                                    sort_action="native",
+                                    sort_mode="multi",
+                                    export_format="csv",
+                                )
+                            ]
+                        )
+                    ],
+                    type="circle",
+                ),
+            ]
+        )
+
+    @property
+    def id_button_options(self) -> str:
+        return self.generate_id(self.ID_BUTTON_OPTIONS)
+
+    @property
+    def id_button_update(self) -> str:
+        return self.generate_id(self.ID_BUTTON_UPDATE)
+
+    @property
+    def id_data_table(self) -> str:
+        return self.generate_id(self.ID_DATA_TABLE)
+
+    @property
+    def id_date_picker(self) -> str:
+        return self.generate_id(self.ID_DATE_PICKER)
+
+    @property
+    def id_drawer(self) -> str:
+        return self.generate_id(self.ID_DRAWER)
+
+    @property
+    def id_loader_data_table(self) -> str:
+        return self.generate_id(self.ID_LOADER_DATATABLE)
+
+    @property
+    def id_loader_graph(self) -> str:
+        return self.generate_id(self.ID_LOADER_GRAPH)
+
+    @property
+    def id_multiselect_kit(self) -> str:
+        return self.generate_id(self.ID_MULTISELECT_KIT)
+
+    @property
+    def id_multiselect_plots(self) -> str:
+        return self.generate_id(self.ID_MULTISELECT_PLOTS)
+
+    @property
+    def id_multiselect_project(self) -> str:
+        return self.generate_id(self.ID_MULTISELECT_PROJECT)
+
+    @property
+    def id_plot(self) -> str:
+        return self.generate_id(self.ID_PLOT)
+
+    @property
+    def id_select_colour(self) -> str:
+        return self.generate_id(self.ID_SELECT_COLOUR)
+
+    @property
+    def id_select_shape(self) -> str:
+        return self.generate_id(self.ID_SELECT_SHAPE)

--- a/application/dash_application/poolqc.py
+++ b/application/dash_application/poolqc.py
@@ -13,9 +13,6 @@ from gsiqcetl.rnaseqqc.constants import CacheSchema as RNASeqQCCacheSchema
 from gsiqcetl.bamqc.constants import CacheSchema as BamQCCacheSchema
 from gsiqcetl.bcl2fastq.constants import SamplesSchema
 
-# TODO: Replace string column names with ETL Column class constants
-# FIXME why doesn't this work the way it does on Dash
-
 page_name = 'pooling_qc'
 
 ids = init_ids([

--- a/application/dash_application/poolqc.py
+++ b/application/dash_application/poolqc.py
@@ -286,7 +286,7 @@ layout = html.Div(children=[
 def init_callbacks(dash_app):
     @dash_app.callback(
         Output(ids['lane_select'], "options"), 
-        [Input("select_a_run", "value")]
+        [Input(ids['select_a_run'], "value")]
     )
     @dash_app.server.cache.memoize(timeout=60)
     def update_lane_options(run_alias):

--- a/application/dash_application/poolqc.py
+++ b/application/dash_application/poolqc.py
@@ -13,8 +13,6 @@ from gsiqcetl.rnaseqqc.constants import CacheSchema as RNASeqQCCacheSchema
 from gsiqcetl.bamqc.constants import CacheSchema as BamQCCacheSchema
 from gsiqcetl.bcl2fastq.constants import SamplesSchema
 
-import pdb
-
 page_name = 'pooling_qc'
 
 ids = init_ids([
@@ -292,7 +290,6 @@ def init_callbacks(dash_app):
     )
     @dash_app.server.cache.memoize(timeout=60)
     def update_lane_options(run_alias):
-        pdb.set_trace()
         run = df[df["Run"] == run_alias]
         run = run[run["Run"].notna()]
         return [
@@ -306,7 +303,6 @@ def init_callbacks(dash_app):
     )
     @dash_app.server.cache.memoize(timeout=60)
     def update_lane_values(available_options):
-        pdb.set_trace()
         return available_options[0]["value"]
 
     @dash_app.callback(
@@ -316,7 +312,6 @@ def init_callbacks(dash_app):
     )
     @dash_app.server.cache.memoize(timeout=60)
     def update_title(lane_value, run_value):
-        pdb.set_trace()
         return "You have selected lane {} in run {}".format(lane_value, run_value)
 
     @dash_app.callback(
@@ -325,7 +320,6 @@ def init_callbacks(dash_app):
     )
     @dash_app.server.cache.memoize(timeout=60)
     def open_project_drawer(n_clicks):
-        pdb.set_trace()
         return n_clicks is not None
 
     @dash_app.callback(
@@ -335,7 +329,6 @@ def init_callbacks(dash_app):
     )
     @dash_app.server.cache.memoize(timeout=60)
     def initial_threshold_value(run_alias, lane_alias):
-        pdb.set_trace()
         run = df[(df["Run"] == run_alias) & (df["LaneNumber"] == lane_alias)]
         run = run.drop_duplicates("library")
 
@@ -380,7 +373,6 @@ def init_callbacks(dash_app):
             pass/fail: calculated value of how many samples have passed dependent on the threshold
             sample_type: the values of all the types of samples selected to view in the report (DNA vs RNA)
         """
-        pdb.set_trace()
         index_threshold = int(index_threshold)
         run = df[(df["Run"] == run_alias) & (df["LaneNumber"] == lane_alias)]
 

--- a/application/dash_application/poolqc.py
+++ b/application/dash_application/poolqc.py
@@ -1,0 +1,516 @@
+import dash_html_components as html
+import dash_core_components as core
+from dash.dependencies import Input, Output
+from .dash_id import init_ids
+import dash_table as table 
+import plotly.graph_objects as go 
+import numpy as np 
+import urllib
+from datetime import datetime
+import sd_material_ui as sd 
+import gsiqcetl.load
+from gsiqcetl.rnaseqqc.constants import CacheSchema as RNASeqQCCacheSchema
+from gsiqcetl.bamqc.constants import CacheSchema as BamQCCacheSchema
+from gsiqcetl.bcl2fastq.constants import SamplesSchema
+
+# TODO: Replace string column names with ETL Column class constants
+# FIXME why doesn't this work the way it does on Dash
+
+page_name = 'pooling_qc'
+
+ids = init_ids([
+    'Filter_drawer',
+    'select_a_run',
+    'lane_select',
+    'index_threshold',
+    'pass/fail',
+    'sample_type',
+    'filters',
+    'Title',
+    'object_threshold',
+    'object_passed_samples',
+    'SampleIndices',
+    'Per Cent Difference', 
+    'download-link',
+    'Summary Table'
+])
+
+rnaseq = gsiqcetl.load.rnaseqqc(RNASeqQCCacheSchema.v1)
+rnaseq_col = gsiqcetl.load.rnaseqqc_columns(RNASeqQCCacheSchema.v1)
+# Column name is being renamed to allow for a seamless merge on column 'library'
+rnaseq.rename(columns={rnaseq_col.SampleName: "library"}, inplace=True)
+
+bamqc = gsiqcetl.load.bamqc(BamQCCacheSchema.v1)
+bamcq_col = gsiqcetl.load.bamqc_columns(BamQCCacheSchema.v1)
+
+bcl2fastq = gsiqcetl.load.bcl2fastq_known_samples(SamplesSchema.v1)
+bcl2fastq_col = gsiqcetl.load.bcl2fastq_known_samples_columns(SamplesSchema.v1)
+
+# Column is being renamed for clarification
+bcl2fastq.rename(columns={bcl2fastq_col.ReadCount: "Clusters"}, inplace=True)
+bcl2fastq["library"] = bcl2fastq[bcl2fastq_col.SampleName].str.extract(
+    r"SWID_\d+_([A-Z0-9]+_\d+_[a-zA-Z]{2}_._[A-Z]{2}_\d+_[A-Z]{2})_"
+)
+
+df = bcl2fastq.merge(rnaseq, on="library", how="outer")
+df = df.merge(bamqc, on="library", how="outer")
+df["Sample Type"] = df["library"].str[-2:]
+df["% Yield over Q30"] = (
+    df[bcl2fastq_col.ReadYieldQ30] / df[bcl2fastq_col.ReadYield] * 100
+)
+
+runs = df[bcl2fastq_col.Run].dropna().sort_values(ascending=False).unique()
+
+layout = html.Div(children=[
+        sd.Drawer(
+            id=ids['Filter_drawer'],
+            width="40%",
+            docked=False,
+            children=[
+                html.Div(
+                    [
+                        html.P(
+                            children="Run Name",
+                            style={
+                                "padding-left": "5px",
+                                "font-weight": "bold",
+                            },
+                        ),
+                        core.Dropdown(
+                            id=ids['select_a_run'],
+                            options=[{"label": r, "value": r} for r in runs],
+                            value=runs[0],
+                            clearable=False,
+                        ),
+                        html.Br(),
+                        html.P(
+                            children="Lane Number",
+                            style={
+                                "padding-left": "5px",
+                                "font-weight": "bold",
+                            },
+                        ),
+                        html.Div(
+                            core.RadioItems(
+                                id=ids['lane_select'],
+                                labelStyle={
+                                    "display": "inline-block",
+                                    "padding-left": "30px",
+                                },
+                            )
+                        ),
+                        html.Br(),
+                        html.P(
+                            children="Threshold Value for Index Clusters",
+                            style={
+                                "padding-left": "5px",
+                                "font-weight": "bold",
+                            },
+                        ),
+                        html.Div(
+                            core.Input(
+                                id=ids['index_threshold'],
+                                placeholder='Press "Enter" when complete',
+                                debounce=True,
+                                type="number",
+                                value="0",
+                            )
+                        ),
+                        html.Br(),
+                        html.P(
+                            children="Sample QC Status",
+                            style={
+                                "padding-left": "5px",
+                                "font-weight": "bold",
+                            },
+                        ),
+                        html.Div(
+                            core.Checklist(
+                                id=ids['pass/fail'],
+                                options=[
+                                    {
+                                        "label": "Passed Samples",
+                                        "value": "Pass",
+                                    },
+                                    {
+                                        "label": "Failed Samples",
+                                        "value": "Fail",
+                                    },
+                                ],
+                                value=["Pass", "Fail"],
+                                labelStyle={"paddingLeft": 30},
+                            )
+                        ),
+                        html.Div(
+                            [
+                                html.P(
+                                    children="Sample Type",
+                                    style={
+                                        "padding-left": "5px",
+                                        "font-weight": "bold",
+                                    },
+                                ),
+                                core.Dropdown(
+                                    id=ids['sample_type'],
+                                    options=[
+                                        {"label": "DNA: WG", "value": "WG"},
+                                        {"label": "DNA: EX", "value": "EX"},
+                                        {"label": "DNA: TS", "value": "TS"},
+                                        {"label": "DNA: AS", "value": "AS"},
+                                        {"label": "RNA: MR", "value": "MR"},
+                                        {"label": "RNA: SM", "value": "SM"},
+                                        {"label": "RNA: WT", "value": "WT"},
+                                        {"label": "RNA: TR", "value": "TR"},
+                                    ],
+                                    value=[
+                                        "WG",
+                                        "EX",
+                                        "TS",
+                                        "AS",
+                                        "MR",
+                                        "SM",
+                                        "WT",
+                                        "TR",
+                                    ],
+                                    clearable=False,
+                                    multi=True,
+                                ),
+                            ]
+                        ),
+                    ]
+                )
+            ],
+        ),
+        sd.RaisedButton(id=ids['filters'], label="Filters"),
+        html.Div(
+            children=[
+                # TODO - URL bug https://jira.oicr.on.ca/browse/GR-755
+                # core.ConfirmDialog(
+                #    id='warning',
+                #   message='The selected run does not return any data. Analysis may have not been completed yet.' '''
+                # '''' Click either "Ok" or "Cancel" to return to the most recent run.'
+                # ),
+                # core.Location(
+                #   id='PBQCrun_url',
+                #  refresh=False
+                # ),
+                html.P(
+                    children="Pool Balancing QC Report",
+                    style={
+                        "fontSize": 35,
+                        "textAlign": "center",
+                        "fontWeight": "900",
+                        "fontFamily": "sans serif",
+                    },
+                ),
+                html.Div(
+                    id=ids['Title'],
+                    style={
+                        "fontSize": 20,
+                        "fontFamily": "sans serif",
+                        "textAlign": "center",
+                        "padding": 30,
+                    },
+                ),
+                html.Br(),
+                html.Div(
+                    sd.Paper(
+                        html.Div(
+                            id=ids['object_threshold'],
+                            style={"fontSize": 20, "fontWeight": "bold"},
+                        ),
+                        style={
+                            "padding": 50,
+                            "background-color": "rgb(222,222,222)",
+                        },
+                    ),
+                    style={
+                        "width": "45%",
+                        "display": "inline-block",
+                        "textAlign": "center",
+                    },
+                ),
+                html.Div(
+                    sd.Paper(
+                        html.Div(
+                            id=ids['object_passed_samples'],
+                            style={"fontSize": 20, "fontWeight": "bold"},
+                        ),
+                        style={
+                            "padding": 50,
+                            "background-color": "rgb(222,222,222)",
+                        },
+                    ),
+                    style={
+                        "width": "45%",
+                        "display": "inline-block",
+                        "textAlign": "center",
+                        "padding": 50,
+                    },
+                ),
+                html.Br(),
+                html.Div(
+                    [
+                        sd.Paper(core.Graph(id=ids['SampleIndices'])),
+                        sd.Paper(core.Graph(id=ids['Per Cent Difference'])),
+                    ],
+                    style={"padding-bottom": 30},
+                ),
+                html.A(
+                    "Download Data",
+                    id=ids['download-link'],
+                    download="rawdata.csv",
+                    href="",
+                    target="_blank",
+                ),
+                html.Div(
+                    table.DataTable(
+                        id=ids['Summary Table'],
+                        style_cell={"minWidth": "150px", "textAlign": "center"},
+                        style_table={
+                            "maxHeight": "1000px",
+                            "maxWidth": "100%",
+                            "overflowY": "scroll",
+                            "overflowX": "scroll",
+                        },
+                        style_header={
+                            "backgroundColor": "rgb(222,222,222)",
+                            "fontSize": 12,
+                            "fontWeight": "bold",
+                            "fontFamily": "sans serif",
+                        },
+                    )
+                ),
+            ],
+            style={"padding-left": 100, "paddingRight": 100},
+        ),
+    ]) 
+
+def init_callbacks(dash_app):
+    @dash_app.callback(
+        Output(ids['lane_select'], "options"), 
+        [Input("select_a_run", "value")]
+    )
+    def update_lane_options(run_alias):
+        run = df[df["Run"] == run_alias]
+        run = run[run["Run"].notna()]
+        return [
+            {"label": i, "value": i}
+            for i in run["LaneNumber"].sort_values(ascending=True).unique()
+        ]
+
+    @dash_app.callback(
+        Output(ids['lane_select'], "value"), 
+        [Input(ids['lane_select'], "options")]
+    )
+    def update_lane_values(available_options):
+        return available_options[0]["value"]
+
+    @dash_app.callback(
+        Output(ids['Title'], "children"),
+        [Input(ids['lane_select'], "value"), 
+        Input(ids['select_a_run'], "value")]
+    )
+    def update_title(lane_value, run_value):
+        return "You have selected lane {} in run {}".format(lane_value, run_value)
+
+    @dash_app.callback(
+        Output(ids['Filter_drawer'], "open"), 
+        [Input(ids['filters'], "n_clicks")]
+    )
+    def open_project_drawer(n_clicks):
+        return n_clicks is not None
+
+    @app.callback(
+        Output(ids['index_threshold'], "value"),
+        [Input(ids['select_a_run'], "value"), 
+        Input(ids['lane_select'], "value")]
+    )
+    def initial_threshold_value(run_alias, lane_alias):
+        run = df[(df["Run"] == run_alias) & (df["LaneNumber"] == lane_alias)]
+        run = run.drop_duplicates("library")
+
+        index_threshold = round(sum(run["Clusters"]) / len(run["library"]))
+        return index_threshold
+
+    @dash_app.callback(
+        [Output(ids['SampleIndices'], "figure"),
+        Output(ids['Per Cent Difference'], "figure"),
+        Output(ids['Summary Table'], "columns"),
+        Output(ids['Summary Table'], "data"),
+        Output(ids['download-link'], "href"),
+        Output(ids['download-link'], "download"),
+        Output(ids['object_threshold'], "children"),
+        Output(ids['object_passed_samples'], "children")],
+        [Input(ids['select_a_run'], "value"),
+        Input(ids['lane_select'], "value"),
+        Input(ids['index_threshold'], "value"),
+        Input(ids['pass/fail'], "value"),
+        Input(ids['sample_type'], "value")]
+    )
+    def update_graphs(
+        run_alias, lane_alias, index_threshold, PassOrFail, sample_type
+    ):
+        """
+        Outputs:
+            SampleIndices: updates the figure Layout element of the graph titled the Index Clusters per Sample
+            Per Cent Difference: updates the figure of Layout element of Per Cent Differences of Index Clusters
+            Summary Table:
+                Columns: updates the names of columns in the Summary Table
+                Data: updates the cells in the Summary Table
+            download-link:
+                href: clickable link to download page for raw data in Summary Table
+                download: csv file for raw data in Summary Table
+            'object_threshold': updates the value of the 'Clusters Threshold' textbox at the top of report
+            'object_passed_samples': updates the value of the 'Passed Samples' textbox at the top of the report
+        Inputs:
+            select_a_run: the value from the run drop-down in drawer
+            lane_select: value selected from lane options in drawer
+            index_threshold: either the calculated initial threshold, or if changed, the new value of index_threshold
+            pass/fail: calculated value of how many samples have passed dependent on the threshold
+            sample_type: the values of all the types of samples selected to view in the report (DNA vs RNA)
+        """
+        index_threshold = int(index_threshold)
+        run = df[(df["Run"] == run_alias) & (df["LaneNumber"] == lane_alias)]
+
+        run = run.drop_duplicates("library")
+        run = run[run["library"].notna()]
+
+        num_libraries = len(run["library"])
+        samples_passing_clusters = "%s/%s" % (
+            sum(i > index_threshold for i in run["Clusters"]),
+            num_libraries,
+        )
+
+        pass_or_fail = []
+        for row in run["Clusters"]:
+            if row >= index_threshold:
+                pass_or_fail.append("Pass")
+            else:
+                pass_or_fail.append("Fail")
+
+        run["Pass/Fail"] = pass_or_fail
+        run = run[run["Pass/Fail"].isin(PassOrFail)]
+
+        run = run[run["Sample Type"].isin(sample_type)]
+
+        downloadtimedate = datetime.today().strftime("%Y-%m-%d")
+        download = "PoolQC_%s_%s_%s.csv" % (downloadtimedate, run_alias, lane_alias)
+
+        columns, data, csv = Summary_table(run)
+
+        return (
+            update_sampleindices(run, index_threshold),
+            percent_difference(run, index_threshold),
+            columns,
+            data,
+            csv,
+            download,
+            ("Clusters Threshold: " + str(index_threshold)),
+            ("Passed Samples: " + str(samples_passing_clusters)),
+        )
+
+def Summary_table(run):
+    # Adding 'on-the-fly' metrics
+    run["Proportion Coding Bases"] = run["Proportion Coding Bases"] * 100
+    run["Proportion Intronic Bases"] = run["Proportion Intronic Bases"] * 100
+    run["Proportion Intergenic Bases"] = (
+        run["Proportion Intergenic Bases"] * 100
+    )
+    run["Proportion Correct Strand Reads"] = (
+        run["Proportion Correct Strand Reads"] * 100
+    )
+
+    run = run.round(2)
+    run = run.filter(
+        [
+            "library",
+            "Run",
+            "LaneNumber",
+            "Index1",
+            "Index2",
+            "Clusters",
+            "rRNA Contamination (%reads aligned)",
+            "Proportion Coding Bases",
+            "Proportion Intronic Bases",
+            "Proportion Intergenic Bases",
+            "Proportion Correct Strand Reads",
+            "Coverage",
+            "% Yield over Q30",
+        ]
+    )
+    run = run.sort_values("library")
+
+    csv = run.to_csv(index=False)
+    csv = "data:text/csv;charset=utf-8," + urllib.parse.quote(csv)
+
+    run = run.drop(columns=["Run", "LaneNumber"])
+    run = run.dropna(axis=1, how="all", thresh=None, subset=None, inplace=False)
+
+    columns = [{"name": i, "id": i, "type": "numeric"} for i in run.columns]
+
+    data = run.to_dict("records")
+
+    return columns, data, csv
+
+
+def update_sampleindices(run, index_threshold):
+    run = run.sort_values("library")
+
+    data = []
+
+    for inx, d in run.groupby(["library"]):
+        data.append(
+            go.Bar(
+                x=list(d["library"]),
+                y=list(d["Clusters"]),
+                name=inx,
+                marker={
+                    "color": np.where(
+                        (d["Clusters"] >= index_threshold), "#20639B", "#db4b4b"
+                    )
+                },
+            )
+        )
+        data.append(
+            go.Scatter(
+                x=list(d["library"]),
+                y=[index_threshold] * len(d),
+                mode="markers+lines",
+                line={"width": 3, "color": "rgb(0,0,0)", "dash": "dash"},
+            )
+        )
+
+    return {
+        "data": data,
+        "layout": {
+            "title": "Index Clusters per Sample",
+            "xaxis": {"title": "Sample", "automargin": True, "tickangle": "90"},
+            "yaxis": {"title": "Clusters"},
+            "showlegend": False,
+            "barmode": "group",
+        },
+    }
+
+
+def percent_difference(run, index_threshold):
+    data = []
+
+    for inx, d in run.groupby("library"):
+        data.append(
+            go.Bar(
+                x=list(d["library"]),
+                y=(d["Clusters"] - index_threshold) / index_threshold * 100,
+                name=inx,
+                marker={"color": "#20639B"},
+            )
+        )
+    return {
+        "data": data,
+        "layout": {
+            "title": "Per Cent Difference of Index Clusters",
+            "xaxis": {"title": "Sample", "automargin": True, "tickangle": "90"},
+            "yaxis": {"title": "Per Cent", "range": [-100, 100]},
+            "showlegend": False,
+        },
+    }

--- a/application/dash_application/poolqc.py
+++ b/application/dash_application/poolqc.py
@@ -13,6 +13,8 @@ from gsiqcetl.rnaseqqc.constants import CacheSchema as RNASeqQCCacheSchema
 from gsiqcetl.bamqc.constants import CacheSchema as BamQCCacheSchema
 from gsiqcetl.bcl2fastq.constants import SamplesSchema
 
+import pdb
+
 page_name = 'pooling_qc'
 
 ids = init_ids([
@@ -290,6 +292,7 @@ def init_callbacks(dash_app):
     )
     @dash_app.server.cache.memoize(timeout=60)
     def update_lane_options(run_alias):
+        pdb.set_trace()
         run = df[df["Run"] == run_alias]
         run = run[run["Run"].notna()]
         return [
@@ -303,6 +306,7 @@ def init_callbacks(dash_app):
     )
     @dash_app.server.cache.memoize(timeout=60)
     def update_lane_values(available_options):
+        pdb.set_trace()
         return available_options[0]["value"]
 
     @dash_app.callback(
@@ -312,6 +316,7 @@ def init_callbacks(dash_app):
     )
     @dash_app.server.cache.memoize(timeout=60)
     def update_title(lane_value, run_value):
+        pdb.set_trace()
         return "You have selected lane {} in run {}".format(lane_value, run_value)
 
     @dash_app.callback(
@@ -320,6 +325,7 @@ def init_callbacks(dash_app):
     )
     @dash_app.server.cache.memoize(timeout=60)
     def open_project_drawer(n_clicks):
+        pdb.set_trace()
         return n_clicks is not None
 
     @dash_app.callback(
@@ -329,6 +335,7 @@ def init_callbacks(dash_app):
     )
     @dash_app.server.cache.memoize(timeout=60)
     def initial_threshold_value(run_alias, lane_alias):
+        pdb.set_trace()
         run = df[(df["Run"] == run_alias) & (df["LaneNumber"] == lane_alias)]
         run = run.drop_duplicates("library")
 
@@ -373,6 +380,7 @@ def init_callbacks(dash_app):
             pass/fail: calculated value of how many samples have passed dependent on the threshold
             sample_type: the values of all the types of samples selected to view in the report (DNA vs RNA)
         """
+        pdb.set_trace()
         index_threshold = int(index_threshold)
         run = df[(df["Run"] == run_alias) & (df["LaneNumber"] == lane_alias)]
 

--- a/application/dash_application/poolqc.py
+++ b/application/dash_application/poolqc.py
@@ -288,6 +288,7 @@ def init_callbacks(dash_app):
         Output(ids['lane_select'], "options"), 
         [Input("select_a_run", "value")]
     )
+    @dash_app.server.cache.memoize(timeout=60)
     def update_lane_options(run_alias):
         run = df[df["Run"] == run_alias]
         run = run[run["Run"].notna()]
@@ -300,6 +301,7 @@ def init_callbacks(dash_app):
         Output(ids['lane_select'], "value"), 
         [Input(ids['lane_select'], "options")]
     )
+    @dash_app.server.cache.memoize(timeout=60)
     def update_lane_values(available_options):
         return available_options[0]["value"]
 
@@ -308,6 +310,7 @@ def init_callbacks(dash_app):
         [Input(ids['lane_select'], "value"), 
         Input(ids['select_a_run'], "value")]
     )
+    @dash_app.server.cache.memoize(timeout=60)
     def update_title(lane_value, run_value):
         return "You have selected lane {} in run {}".format(lane_value, run_value)
 
@@ -315,14 +318,16 @@ def init_callbacks(dash_app):
         Output(ids['Filter_drawer'], "open"), 
         [Input(ids['filters'], "n_clicks")]
     )
+    @dash_app.server.cache.memoize(timeout=60)
     def open_project_drawer(n_clicks):
         return n_clicks is not None
 
-    @app.callback(
+    @dash_app.callback(
         Output(ids['index_threshold'], "value"),
         [Input(ids['select_a_run'], "value"), 
         Input(ids['lane_select'], "value")]
     )
+    @dash_app.server.cache.memoize(timeout=60)
     def initial_threshold_value(run_alias, lane_alias):
         run = df[(df["Run"] == run_alias) & (df["LaneNumber"] == lane_alias)]
         run = run.drop_duplicates("library")
@@ -345,6 +350,7 @@ def init_callbacks(dash_app):
         Input(ids['pass/fail'], "value"),
         Input(ids['sample_type'], "value")]
     )
+    @dash_app.server.cache.memoize(timeout=60) #That might take a lot of memory 
     def update_graphs(
         run_alias, lane_alias, index_threshold, PassOrFail, sample_type
     ):

--- a/application/dash_application/rnaseqc.py
+++ b/application/dash_application/rnaseqc.py
@@ -1,0 +1,137 @@
+import dash_html_components as html
+import dash_core_components as core
+from dash.dependencies import Input, Output
+from .dash_id import init_ids
+import pandas
+import gsiqcetl.load
+from gsiqcetl.rnaseqqc.constants import CacheSchema
+from gsiqcetl.pinery.sampleprovenance.constants import (
+    CacheSchema as SampleProvenanceCacheSchema
+)
+
+from application.dash_application.plots.shiny_mimic import ShinyMimic
+
+page_name = 'rnaseqc/over_time'
+
+RNA_DF = gsiqcetl.load.rnaseqqc(CacheSchema.v2)
+RNA_COL = gsiqcetl.load.rnaseqqc_columns(CacheSchema.v2)
+
+COL_RUN_DATE = "Run Date"
+COL_PROP_ALIGNED_BASES = "Proportion Aligned Bases"
+
+# The Run Name is used to extract the date
+RNA_DF[COL_RUN_DATE] = (
+    RNA_DF[RNA_COL.SequencerRunName].dropna().apply(lambda x: x.split("_")[0])
+)
+# Some runs do not have the proper format and will be excluded
+RNA_DF = RNA_DF[RNA_DF[COL_RUN_DATE].str.isnumeric()]
+RNA_DF[COL_RUN_DATE] = pandas.to_datetime(RNA_DF[COL_RUN_DATE], yearfirst=True)
+
+RNA_DF[COL_PROP_ALIGNED_BASES] = (
+    RNA_DF[RNA_COL.PassedFilterAlignedBases] / RNA_DF[RNA_COL.PassedFilterBases]
+)
+
+# List projects for which RNA-Seq studies have been done
+ALL_PROJECTS = RNA_DF[RNA_COL.StudyTitle].sort_values().unique()
+
+# Pull in meta data from Pinery
+# noinspection PyTypeChecker
+PINERY: pandas.DataFrame = gsiqcetl.load.pinery_sample_provenance(
+    SampleProvenanceCacheSchema.v1
+)
+PINERY_COL = gsiqcetl.load.pinery_sample_provenance_columns(
+    SampleProvenanceCacheSchema.v1
+)
+
+PINERY = PINERY[
+    [
+        PINERY_COL.SampleName,
+        PINERY_COL.SequencerRunName,
+        PINERY_COL.LaneNumber,
+        PINERY_COL.PrepKit,
+        PINERY_COL.LibrarySourceTemplateType,
+        PINERY_COL.TissueOrigin,
+        PINERY_COL.TissueType,
+        PINERY_COL.TissuePreparation,
+    ]
+]
+
+RNA_DF = RNA_DF.merge(
+    PINERY,
+    how="left",
+    left_on=[RNA_COL.SampleName, RNA_COL.SequencerRunName, RNA_COL.LaneNumber],
+    right_on=[
+        PINERY_COL.SampleName,
+        PINERY_COL.SequencerRunName,
+        PINERY_COL.LaneNumber,
+    ],
+)
+
+# NaN kits need to be changed to a str. Use the existing Unspecified
+RNA_DF = RNA_DF.fillna({PINERY_COL.PrepKit: "Unspecified"})
+RNA_DF = RNA_DF.fillna({PINERY_COL.LibrarySourceTemplateType: "Unknown"})
+# NaN Tissue Origin is set to `nn`, which is used by MISO for unknown
+RNA_DF = RNA_DF.fillna({PINERY_COL.TissueOrigin: "nn"})
+# NaN Tissue Type is set to `n`, which is used by MISO for unknown
+RNA_DF = RNA_DF.fillna({PINERY_COL.TissueType: "n"})
+RNA_DF = RNA_DF.fillna({PINERY_COL.TissuePreparation: "Unknown"})
+
+# Kits used for RNA-Seq experiments
+ALL_KITS = RNA_DF[PINERY_COL.PrepKit].sort_values().unique()
+
+# Which metrics can be plotted
+METRICS_TO_GRAPH = (
+    RNA_COL.ProportionUsableBases,
+    RNA_COL.rRNAContaminationreadsaligned,
+    RNA_COL.ProportionCorrectStrandReads,
+    COL_PROP_ALIGNED_BASES,
+    RNA_COL.ProportionCodingBases,
+    RNA_COL.ProportionIntronicBases,
+    RNA_COL.ProportionIntergenicBases,
+    RNA_COL.ProportionUTRBases,
+)
+
+# Which columns will the data table always have
+DEFAULT_TABLE_COLUMN = [
+    {"name": "Library", "id": RNA_COL.SampleName},
+    {"name": "Project", "id": RNA_COL.StudyTitle},
+    {"name": "Run", "id": RNA_COL.SequencerRunName},
+    {"name": "Lane", "id": RNA_COL.LaneNumber},
+    {"name": "Kit", "id": PINERY_COL.PrepKit},
+    {"name": "Library Design", "id": PINERY_COL.LibrarySourceTemplateType},
+    {"name": "Tissue Origin", "id": PINERY_COL.TissueOrigin},
+    {"name": "Tissue Type", "id": PINERY_COL.TissueType},
+    {"name": "Tissue Material", "id": PINERY_COL.TissuePreparation},
+]
+
+# Columns on which shape and colour can be set
+SHAPE_COLOUR_COLUMN = [
+    {"name": "Project", "id": RNA_COL.StudyTitle},
+    {"name": "Kit", "id": PINERY_COL.PrepKit},
+    {"name": "Library Design", "id": PINERY_COL.LibrarySourceTemplateType},
+    {"name": "Tissue Origin", "id": PINERY_COL.TissueOrigin},
+    {"name": "Tissue Type", "id": PINERY_COL.TissueType},
+    {"name": "Tissue Material", "id": PINERY_COL.TissuePreparation},
+]
+
+plot_creator = ShinyMimic(
+    lambda: RNA_DF,
+    "rnaseqqc_over_time",
+    METRICS_TO_GRAPH,
+    SHAPE_COLOUR_COLUMN,
+    SHAPE_COLOUR_COLUMN,
+    RNA_COL.StudyTitle,
+    PINERY_COL.PrepKit,
+    COL_RUN_DATE,
+    RNA_COL.SampleName,
+)
+
+layout = plot_creator.generate_layout(
+    4,
+    RNA_COL.StudyTitle,
+    PINERY_COL.PrepKit,
+    DEFAULT_TABLE_COLUMN + [{"name": i, "id": i} for i in METRICS_TO_GRAPH],
+)
+
+def init_callbacks(dash_app):
+    plot_creator.assign_callbacks(dash_app)

--- a/application/dash_application/runreport.py
+++ b/application/dash_application/runreport.py
@@ -71,6 +71,7 @@ def init_callbacks(dash_app):
     @dash_app.callback(
         Output(ids['focused_run'], "options"), 
         [Input(ids['project'], "value")])
+    @dash_app.server.cache.memoize(timeout=60)
     def set_focused_run_based_on_project(project):
         runs = (
             rr.loc[idx[project, :], :].index.get_level_values(rr_col.Run).unique()
@@ -92,6 +93,7 @@ def init_callbacks(dash_app):
         Output(ids['coverage_dist'], "figure"),
         [Input(ids['project'], "value"), 
         Input(ids['focused_run'], "value")])
+    @dash_app.server.cache.memoize(timeout=60)
     def create_coverage_dist(project, run_to_focus):
         highlight = rr.loc[idx[project, run_to_focus], rr_col.Coverage]
 
@@ -122,5 +124,6 @@ def init_callbacks(dash_app):
     @dash_app.callback(
         Output(ids['click-data'], "children"), 
         [Input(ids['coverage_dist'], "clickData")])
+    @dash_app.server.cache.memoize(timeout=60)
     def display_click_data(clickData):
         return json.dumps(clickData, indent=2)

--- a/application/dash_application/runreport.py
+++ b/application/dash_application/runreport.py
@@ -1,0 +1,126 @@
+import dash_html_components as html
+import dash_core_components as core
+from dash.dependencies import Input, Output
+from .dash_id import init_ids
+import json
+import pandas
+import numpy
+import plotly.figure_factory as ff
+
+import gsiqcetl.load
+from gsiqcetl.runreport.constants import CacheSchema
+
+page_name = "runreport/proj_hist"
+
+ids = init_ids([
+    'project',
+    'focused_run',
+    'coverage_dist',
+    'click-data'
+])
+
+idx = pandas.IndexSlice
+
+rr = gsiqcetl.load.runreport(CacheSchema.v1)
+rr_col = gsiqcetl.load.runreport_columns(CacheSchema.v1)
+
+COL_PROJECT = "Project"
+
+rr[COL_PROJECT] = rr[rr_col.Library].apply(lambda x: x.split("_", 1)[0])
+rr.set_index([COL_PROJECT, rr_col.Run], inplace=True)
+rr.sort_values([rr_col.Run, COL_PROJECT], ascending=False, inplace=True)
+
+# Count how many runs per project
+runs_per_proj_count = (
+    rr.reset_index().groupby(COL_PROJECT)[rr_col.Run].nunique()
+)
+proj_with_multi_run = runs_per_proj_count[runs_per_proj_count > 1].index
+# Only display project that have more than one run
+rr = rr.loc[idx[proj_with_multi_run, :], :]
+
+rr = rr.groupby([COL_PROJECT, rr_col.Run]).filter(lambda x: len(x) > 1)
+
+proj_list = list(rr.index.get_level_values(COL_PROJECT).unique())
+proj_top = proj_list[0]
+proj_list.sort()
+
+run_list = list(
+    rr.loc[idx[proj_top, :], :].index.get_level_values(rr_col.Run).unique()
+)
+
+layout = html.Div(
+    [
+        core.Dropdown(
+            id=ids['project'],
+            options=[{"label": v, "value": v} for v in proj_list],
+            value=proj_top,
+            clearable=False,
+        ),
+        core.Dropdown(id=ids['focused_run'], clearable=False),
+        # core.Graph(
+        #     id='coverage_hist'
+        # ),
+        core.Graph(id=ids['coverage_dist']),
+        html.Pre(id=ids['click-data'])
+    ]
+)
+
+def init_callbacks(dash_app):
+    # When a project is selected,
+    # show only runs where the project is found
+    @dash_app.callback(
+        Output(ids['focused_run'], "options"), 
+        [Input(ids['project'], "value")])
+    def set_focused_run_based_on_project(project):
+        runs = (
+            rr.loc[idx[project, :], :].index.get_level_values(rr_col.Run).unique()
+        )
+
+        return [{"label": v, "value": v} for v in runs]
+
+    # When a project is selected
+    # Set the newest run as the default selection
+    @dash_app.callback(
+        Output(ids['focused_run'], "value"), 
+        [Input(ids['project'], "value")])
+    def set_focused_run_default_value_when_options_change(project):
+        runs = rr.loc[idx[project, :], :].index.get_level_values("Run").unique()
+
+        return list(runs)[0]
+
+    @dash_app.callback(
+        Output(ids['coverage_dist'], "figure"),
+        [Input(ids['project'], "value"), 
+        Input(ids['focused_run'], "value")])
+    def create_coverage_dist(project, run_to_focus):
+        highlight = rr.loc[idx[project, run_to_focus], rr_col.Coverage]
+
+        other_runs = rr.index.get_level_values(rr_col.Run).difference(
+            highlight.index.get_level_values(rr_col.Run)
+        )
+
+        other_runs_data = rr.loc[idx[project, other_runs], rr_col.Coverage]
+
+        if len(other_runs_data.unique()) < 2:
+            return []
+
+        try:
+            if len(other_runs_data) > 0:
+                return ff.create_distplot(
+                    [list(highlight), list(other_runs_data)],
+                    ["Selected Run", "All Other Runs"],
+                )
+            else:
+                return ff.create_distplot([list(highlight)], ["Selected Run"])
+        # Thrown if all data points have the same value
+        except numpy.linalg.linalg.LinAlgError:
+            return ff.create_distplot([list(other_runs_data)], ["All Other Run"])
+        # If data set only has one value
+        except ValueError:
+            return ff.create_distplot([list(other_runs_data)], ["All Other Run"])
+
+    @dash_app.callback(
+        Output(ids['click-data'], "children"), 
+        [Input(ids['coverage_dist'], "clickData")])
+    def display_click_data(clickData):
+        return json.dumps(clickData, indent=2)

--- a/application/dash_application/runscanner.py
+++ b/application/dash_application/runscanner.py
@@ -65,7 +65,7 @@ raw_df_table_col_names = [{"name": i, "id": i} for i in raw_df.columns]
 layout = html.Div(
     [
         core.Dropdown(
-            id="freq_dropdown",
+            id=ids['freq_dropdown'],
             options=[
                 {"label": "Daily", "value": "D"},
                 {"label": "Weekly", "value": "W"},
@@ -77,7 +77,7 @@ layout = html.Div(
             clearable=False,
         ),
         core.Dropdown(
-            id="colour_by_dropdown",
+            id=ids['colour_by_dropdown'],
             options=[
                 {"label": "Machine ID", "value": inst_col.InstrumentName},
                 {"label": "Machine Model", "value": inst_col.ModelName},
@@ -85,22 +85,22 @@ layout = html.Div(
             value=None,
             placeholder="Colour By",
         ),
-        core.Graph(id="bar_sum"),
+        core.Graph(id=ids['bar_sum']),
         core.Tabs(
-            id="table_tabs",
+            id=ids['table_tabs'],
             value="grouped",
             children=[
                 core.Tab(label="Grouped Data", value="grouped"),
                 core.Tab(label="All Data", value="all"),
             ],
         ),
-        html.Div(id="table_tabs_content"),
+        html.Div(id=ids['table_tabs_content']),
         html.Div(
-            id="raw_df_json",
+            id=ids['raw_df_json'],
             style={"display": "none"},
             children=raw_df.to_json(date_format="iso", orient="records"),
         ),
-        html.Div(id="df_group_sum", style={"display": "none"}),
+        html.Div(id=ids['df_group_sum'], style={"display": "none"}),
     ]
 ) 
 
@@ -109,6 +109,7 @@ def init_callbacks(dash_app):
         Output(ids['bar_sum'], "figure"),
         [Input(ids['df_group_sum'], "children"), 
         Input(ids['colour_by_dropdown'], "value")])
+    @dash_app.server.cache.memoize(timeout=60)
     def create_bar_sum_fig(df_group_sum, colour_by):
         df = pandas.read_json(df_group_sum, orient="split")
 
@@ -142,6 +143,7 @@ def init_callbacks(dash_app):
         [Input(ids['table_tabs'], "value"),
         Input(ids['raw_df_json'], "children"),
         Input(ids['df_group_sum'], "children")])
+    @dash_app.server.cache.memoize(timeout=60)
     def update_table_tab(selected_tab, raw_df_json, group_df_json):
         if selected_tab == "grouped":
             df = pandas.read_json(group_df_json, orient="split")
@@ -160,6 +162,7 @@ def init_callbacks(dash_app):
         [Input(ids['raw_df_json'], "children"),
         Input(ids['freq_dropdown'], "value"),
         Input(ids['colour_by_dropdown'], "value")])
+    @dash_app.server.cache.memoize(timeout=60)
     def update_grouped_df(raw_df_json, frequency, colour_grouper):
         raw = pandas.read_json(
             raw_df_json, orient="records", convert_dates=[rs_flow_col.StartDate]

--- a/application/dash_application/runscanner.py
+++ b/application/dash_application/runscanner.py
@@ -1,0 +1,181 @@
+import dash_html_components as html
+import dash_core_components as core
+from dash.dependencies import Input, Output
+from .dash_id import init_ids
+import dash_table
+import pandas
+import plotly.graph_objects as go
+import gsiqcetl.load
+from gsiqcetl.runscanner.illumina.constants import FlowCellCacheSchema
+from gsiqcetl.pinery.instruments.constants import CacheSchema
+
+page_name = 'runscanner/sum_over_time'
+
+ids = init_ids([
+    'freq_dropdown',
+    'colour_by_dropdown',
+    'bar_sum',
+    'table_tabs',
+    'table_tabs_content',
+    'raw_df_json',
+    'df_group_sum'
+])
+
+rs_flow = gsiqcetl.load.runscanner_illumina_flowcell(FlowCellCacheSchema.v1)
+rs_flow_col = gsiqcetl.load.runscanner_illumina_flowcell_columns(
+    FlowCellCacheSchema.v1
+)
+
+COL_TOTAL_YIELD = "Total Yield (GB)"
+
+rs_flow[COL_TOTAL_YIELD] = rs_flow[
+    [
+        rs_flow_col.YieldRead1,
+        rs_flow_col.YieldRead2,
+        rs_flow_col.YieldIndex1,
+        rs_flow_col.YieldIndex2,
+    ]
+].sum(axis=1)
+
+rs_flow = rs_flow[
+    [
+        rs_flow_col.SequencerName,
+        rs_flow_col.StartDate,
+        rs_flow_col.HealthType,
+        COL_TOTAL_YIELD,
+    ]
+]
+
+inst_raw = gsiqcetl.load.pinery_instruments(CacheSchema.v1)
+inst_col = gsiqcetl.load.pinery_instruments_columns(CacheSchema.v1)
+
+inst_model = inst_raw[[inst_col.InstrumentName, inst_col.ModelName]]
+
+rs_flow = rs_flow.merge(
+    inst_model,
+    "left",
+    left_on=rs_flow_col.SequencerName,
+    right_on=inst_col.InstrumentName,
+)
+
+raw_df = rs_flow[rs_flow[rs_flow_col.HealthType] == "COMPLETED"]
+
+raw_df_table_col_names = [{"name": i, "id": i} for i in raw_df.columns]
+
+layout = html.Div(
+    [
+        core.Dropdown(
+            id="freq_dropdown",
+            options=[
+                {"label": "Daily", "value": "D"},
+                {"label": "Weekly", "value": "W"},
+                {"label": "Monthly", "value": "M"},
+                {"label": "Quarterly", "value": "BQ-MAR"},
+                {"label": "Yearly", "value": "Y"},
+            ],
+            value="M",
+            clearable=False,
+        ),
+        core.Dropdown(
+            id="colour_by_dropdown",
+            options=[
+                {"label": "Machine ID", "value": inst_col.InstrumentName},
+                {"label": "Machine Model", "value": inst_col.ModelName},
+            ],
+            value=None,
+            placeholder="Colour By",
+        ),
+        core.Graph(id="bar_sum"),
+        core.Tabs(
+            id="table_tabs",
+            value="grouped",
+            children=[
+                core.Tab(label="Grouped Data", value="grouped"),
+                core.Tab(label="All Data", value="all"),
+            ],
+        ),
+        html.Div(id="table_tabs_content"),
+        html.Div(
+            id="raw_df_json",
+            style={"display": "none"},
+            children=raw_df.to_json(date_format="iso", orient="records"),
+        ),
+        html.Div(id="df_group_sum", style={"display": "none"}),
+    ]
+) 
+
+def init_callbacks(dash_app):
+    @dash_app.callback(
+        Output(ids['bar_sum'], "figure"),
+        [Input(ids['df_group_sum'], "children"), 
+        Input(ids['colour_by_dropdown'], "value")])
+    def create_bar_sum_fig(df_group_sum, colour_by):
+        df = pandas.read_json(df_group_sum, orient="split")
+
+        layout = {
+            "yaxis": {"title": "PF Yield (GB)"},
+            "legend": {"orientation": "h"},
+        }
+
+        if colour_by is None:
+            return {
+                "data": [
+                    go.Bar(x=df[rs_flow_col.StartDate], y=df[COL_TOTAL_YIELD])
+                ],
+                "layout": layout,
+            }
+        else:
+            traces = []
+            for name, data in df.groupby(colour_by):
+                t = go.Bar(
+                    x=list(data[rs_flow_col.StartDate]),
+                    y=list(data[COL_TOTAL_YIELD]),
+                    name=name,
+                )
+                traces.append(t)
+
+            return {"data": traces, "layout": layout}
+
+
+    @dash_app.callback(
+        Output(ids['table_tabs_content'], "children"),
+        [Input(ids['table_tabs'], "value"),
+        Input(ids['raw_df_json'], "children"),
+        Input(ids['df_group_sum'], "children")])
+    def update_table_tab(selected_tab, raw_df_json, group_df_json):
+        if selected_tab == "grouped":
+            df = pandas.read_json(group_df_json, orient="split")
+        if selected_tab == "all":
+            df = pandas.read_json(raw_df_json, orient="records")
+
+        col_names = [{"name": i, "id": i} for i in df.columns]
+
+        return dash_table.DataTable(
+            id="test", columns=col_names, data=df.to_dict("rows")
+        )
+
+
+    @dash_app.callback(
+        Output(ids['df_group_sum'], "children"),
+        [Input(ids['raw_df_json'], "children"),
+        Input(ids['freq_dropdown'], "value"),
+        Input(ids['colour_by_dropdown'], "value")])
+    def update_grouped_df(raw_df_json, frequency, colour_grouper):
+        raw = pandas.read_json(
+            raw_df_json, orient="records", convert_dates=[rs_flow_col.StartDate]
+        )
+
+        if colour_grouper is None:
+            grouper = [pandas.Grouper(key=rs_flow_col.StartDate, freq=frequency)]
+        else:
+            grouper = [
+                pandas.Grouper(key=rs_flow_col.StartDate, freq=frequency),
+                colour_grouper,
+            ]
+
+        return (
+            raw.groupby(grouper)
+            .sum()
+            .reset_index()
+            .to_json(date_format="iso", orient="split")
+        )

--- a/application/dash_application/url_handler.py
+++ b/application/dash_application/url_handler.py
@@ -2,7 +2,7 @@ import dash_html_components as html
 import dash_core_components as core
 from dash.dependencies import Input, Output
 from .dash_id import init_ids
-from . import bcl2fastq
+from . import bcl2fastq, bamqc_gbovertime, poolqc
 
 ids = init_ids(['url', 'page-content'])
 
@@ -11,7 +11,6 @@ layout = html.Div([
     html.Div(id=ids['page-content'])
 ]) 
 
-## Please define all callbacks inside this procedure
 def init_callbacks(dash_app):
     dash_app.config.suppress_callback_exceptions = True
 
@@ -21,5 +20,9 @@ def init_callbacks(dash_app):
     def url_handler(path):
         if path == '/{0}'.format(bcl2fastq.page_name):
             return bcl2fastq.layout
+        elif path == '/{0}'.format(bamqc_gbovertime.page_name):
+            return bamqc_gbovertime.layout
+        elif path == '/{0}'.format(poolqc.page_name):
+            return poolqc.layout
         else:
             return '404'

--- a/application/dash_application/url_handler.py
+++ b/application/dash_application/url_handler.py
@@ -2,7 +2,7 @@ import dash_html_components as html
 import dash_core_components as core
 from dash.dependencies import Input, Output
 from .dash_id import init_ids
-from . import bcl2fastq, bamqc_gbovertime, poolqc, runreport, runscanner, bamqc_overtime
+from . import bcl2fastq, bamqc_gbovertime, poolqc, runreport, runscanner, bamqc_overtime, rnaseqc
 
 ids = init_ids(['url', 'page-content'])
 
@@ -31,5 +31,7 @@ def init_callbacks(dash_app):
             return runscanner.layout
         elif path == '/{0}'.format(bamqc_overtime.page_name):
             return bamqc_overtime.layout
+        elif path == '/{0}'.format(rnaseqc.page_name):
+            return rnaseqc.layout
         else:
             return '404'

--- a/application/dash_application/url_handler.py
+++ b/application/dash_application/url_handler.py
@@ -2,7 +2,7 @@ import dash_html_components as html
 import dash_core_components as core
 from dash.dependencies import Input, Output
 from .dash_id import init_ids
-from . import bcl2fastq, bamqc_gbovertime, poolqc
+from . import bcl2fastq, bamqc_gbovertime, poolqc, runreport
 
 ids = init_ids(['url', 'page-content'])
 
@@ -24,5 +24,7 @@ def init_callbacks(dash_app):
             return bamqc_gbovertime.layout
         elif path == '/{0}'.format(poolqc.page_name):
             return poolqc.layout
+        elif path == '/{0}'.format(runreport.page_name):
+            return runreport.layout
         else:
             return '404'

--- a/application/dash_application/url_handler.py
+++ b/application/dash_application/url_handler.py
@@ -2,7 +2,9 @@ import dash_html_components as html
 import dash_core_components as core
 from dash.dependencies import Input, Output
 from .dash_id import init_ids
-from . import bcl2fastq, bamqc_gbovertime, poolqc, runreport, runscanner, bamqc_overtime, rnaseqc
+from . import pages
+
+page_name = None
 
 ids = init_ids(['url', 'page-content'])
 
@@ -14,24 +16,12 @@ layout = html.Div([
 def init_callbacks(dash_app):
     dash_app.config.suppress_callback_exceptions = True
 
-    # TODO: use pages.py or sOMETHING
+    # TODO: You can hang dashi and potentially DoS it by going to <dashi-url>/None
     @dash_app.callback(
         Output(ids['page-content'], 'children'),
         [Input(ids['url'], 'pathname')])
     def url_handler(path):
-        if path == '/{0}'.format(bcl2fastq.page_name):
-            return bcl2fastq.layout
-        elif path == '/{0}'.format(bamqc_gbovertime.page_name):
-            return bamqc_gbovertime.layout
-        elif path == '/{0}'.format(poolqc.page_name):
-            return poolqc.layout
-        elif path == '/{0}'.format(runreport.page_name):
-            return runreport.layout
-        elif path == '/{0}'.format(runscanner.page_name):
-            return runscanner.layout
-        elif path == '/{0}'.format(bamqc_overtime.page_name):
-            return bamqc_overtime.layout
-        elif path == '/{0}'.format(rnaseqc.page_name):
-            return rnaseqc.layout
-        else:
-            return '404'
+        for page in pages.pages:
+            if path == '/{0}'.format(page.page_name):
+                return page.layout
+        return '404'

--- a/application/dash_application/url_handler.py
+++ b/application/dash_application/url_handler.py
@@ -2,7 +2,7 @@ import dash_html_components as html
 import dash_core_components as core
 from dash.dependencies import Input, Output
 from .dash_id import init_ids
-from . import bcl2fastq, bamqc_gbovertime, poolqc, runreport
+from . import bcl2fastq, bamqc_gbovertime, poolqc, runreport, runscanner, bamqc_overtime
 
 ids = init_ids(['url', 'page-content'])
 
@@ -14,6 +14,7 @@ layout = html.Div([
 def init_callbacks(dash_app):
     dash_app.config.suppress_callback_exceptions = True
 
+    # TODO: use pages.py or sOMETHING
     @dash_app.callback(
         Output(ids['page-content'], 'children'),
         [Input(ids['url'], 'pathname')])
@@ -26,5 +27,9 @@ def init_callbacks(dash_app):
             return poolqc.layout
         elif path == '/{0}'.format(runreport.page_name):
             return runreport.layout
+        elif path == '/{0}'.format(runscanner.page_name):
+            return runscanner.layout
+        elif path == '/{0}'.format(bamqc_overtime.page_name):
+            return bamqc_overtime.layout
         else:
             return '404'

--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -7,7 +7,7 @@
 		<h1>Dashi</h1>
 		<h2>BamQC</h2>
 		<h3><a href="/bamqc/gbovertime">Gigabases produced over time</a></h3>
-		<!--<h3><a href="/bamqc/shiny">Shiny</a></h3>-->
+		<h3><a href="/bamqc/shiny">Shiny</a></h3>
 
 		<h2>bcl2fastq</h2>
 		<h3><a href="/bcl2fastq/indexinfo">Known and unknown indexes per run</a></h3>

--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -21,8 +21,8 @@
 		<h2>Run Scanner</h2>
 		<h3><a href="/runscanner/sum_over_time">Pass filter yield over time</a></h3>
 
-		<!--<h2>QC Reports</h2>
-		<h3><a href="/pooling_qc">Pool Balancing QC</a></h3>-->
+		<h2>QC Reports</h2>
+		<h3><a href="/pooling_qc">Pool Balancing QC</a></h3>
 	</body>
 </html>
 

--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -7,7 +7,7 @@
 		<h1>Dashi</h1>
 		<h2>BamQC</h2>
 		<h3><a href="/bamqc/gbovertime">Gigabases produced over time</a></h3>
-		<h3><a href="/bamqc/shiny">Shiny</a></h3>
+		<!--<h3><a href="/bamqc/shiny">Shiny</a></h3>-->
 
 		<h2>bcl2fastq</h2>
 		<h3><a href="/bcl2fastq/indexinfo">Known and unknown indexes per run</a></h3>
@@ -21,8 +21,8 @@
 		<h2>Run Scanner</h2>
 		<h3><a href="/runscanner/sum_over_time">Pass filter yield over time</a></h3>
 
-		<h2>QC Reports</h2>
-		<h3><a href="/pooling_qc">Pool Balancing QC</a></h3>
+		<!--<h2>QC Reports</h2>
+		<h3><a href="/pooling_qc">Pool Balancing QC</a></h3>-->
 	</body>
 </html>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ prometheus_flask_exporter==0.11.0
 plotly==4.2.1
 git+https://bitbucket.oicr.on.ca/scm/gsi/gsi-qc-etl.git@v0.5.0
 sd-material-ui==3.1.2
+scipy==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ dash==1.4.1
 prometheus_flask_exporter==0.11.0
 plotly==4.2.1
 git+https://bitbucket.oicr.on.ca/scm/gsi/gsi-qc-etl.git@v0.5.0
+sd-material-ui==3.1.2


### PR DESCRIPTION
All but poolqc and bamqc_overtime ("shiny") work. Broken reports have been hidden from main menu but should still be accessible by URL.

Aside from rather adjustments to platonic architecture, report design and logic is unchanged (/plots directory is copied wholesale). Memoization is applied without finesse