### PR TITLE
[GR-967] end_date adjustments for log aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,14 @@ and as of version 1.0.0, follows semantic versioning.
   * Bcl2Fastq Index QC graph
   * Set `DASHI_LOG_TO_CONSOLE=True` in `.env` file to log to console
   * Set `USE_BLEEDING_EDGE_ETL=1` in `.env` file to use gsi-qc-etl@master (development only)
+### Changed
+  * Filter logs now remove `end_date` if it is the current date
+  * Filter logs now report `end_date` as a date rather than datetime
+  * Filter logs now report `["all_runs"]` when all runs have been selected; etc for other dropdowns
 ### Fixed
   * `nav_handler` and `content_handler` no longer throw exception on empty path
+  * `Add All` button for Library Designs on WGS report now works
+  * Remove blank Run from TS and RNA dropdowns
 
 ## [200114-1651] - 2020-01-14
 ### Added

--- a/application/dash_application/known_pages_router.py
+++ b/application/dash_application/known_pages_router.py
@@ -52,7 +52,7 @@ layout = html.Div([
     core.Location(id='url', refresh=False),
     navbar(default_title),
     core.Loading(id='page-content', type='dot'),
-    html.Footer(id='footer', children=[html.Hr(), "Dash version {0}".format(version)])
+    html.Footer(id='footer', children=[html.Hr(), "Dash version {0} | Data version ".format(version), html.Span(id='data-version')])
 ])
 
 

--- a/application/dash_application/known_pages_router.py
+++ b/application/dash_application/known_pages_router.py
@@ -51,8 +51,8 @@ def navbar(current):
 layout = html.Div([
     core.Location(id='url', refresh=False),
     navbar(default_title),
-    core.Loading(id='page-content'),
-    html.Footer(id='footer', children=[html.Hr(), "Dash version {0} | Data version ".format(version), html.Span(id='data-version')])
+    core.Loading(id='page-content', type='dot'),
+    html.Footer(id='footer', children=[html.Hr(), "Dash version {0}".format(version)])
 ])
 
 

--- a/application/dash_application/utility/log_utils.py
+++ b/application/dash_application/utility/log_utils.py
@@ -4,7 +4,6 @@ from typing import List
 import datetime
 import logging
 import json
-import pdb
 
 compare = lambda s, t: Counter(s) == Counter(t)
 

--- a/application/dash_application/utility/log_utils.py
+++ b/application/dash_application/utility/log_utils.py
@@ -1,0 +1,38 @@
+from collections import Counter
+
+import datetime
+import logging
+import json
+
+compare = lambda s, t: Counter(s) == Counter(t)
+
+# N.B. The keys in this object must match the argument names for
+# the `update_pressed` function in the views.
+collapsing_functions = {
+    "projects": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_PROJECTS, "all_projects"),
+    "runs": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_RUNS, "all_runs"),
+    "kits": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_KITS, "all_kits"),
+    "instruments": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ILLUMINA_INSTRUMENT_MODELS, "all_instruments"),
+    "library_designs": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_LIBRARY_DESIGNS, "all_library_designs"),
+}
+
+def collapse_if_all_selected(selected_items: List[str], all_items: List[str], all_title: str) -> List[str]:
+    if compare(selected_items, all_items):
+        return [all_title]
+    else:
+        return selected_items
+
+
+def collapse_all_params(params):
+    """ Iterate over params values and simplify them if possible """
+    for key in collapsing_functions.keys():
+        params[key] = collapsing_functions[key](params[key])
+    return params
+
+
+def log_filters(params, logger):
+    collapse_all_params(params)
+    del params['click']
+    if datetime.datetime.strptime(params['end_date'], '%Y-%m-%d').date() == datetime.date.today():
+        del params['end_date']
+    logger.info(json.dumps(params))

--- a/application/dash_application/utility/log_utils.py
+++ b/application/dash_application/utility/log_utils.py
@@ -1,37 +1,29 @@
 from collections import Counter
+from typing import List
 
 import datetime
 import logging
 import json
+import pdb
 
 compare = lambda s, t: Counter(s) == Counter(t)
 
-# N.B. The keys in this object must match the argument names for
-# the `update_pressed` function in the views.
-collapsing_functions = {
-    "projects": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_PROJECTS, "all_projects"),
-    "runs": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_RUNS, "all_runs"),
-    "kits": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_KITS, "all_kits"),
-    "instruments": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ILLUMINA_INSTRUMENT_MODELS, "all_instruments"),
-    "library_designs": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_LIBRARY_DESIGNS, "all_library_designs"),
-}
-
 def collapse_if_all_selected(selected_items: List[str], all_items: List[str], all_title: str) -> List[str]:
     if compare(selected_items, all_items):
-        return [all_title]
+        return [all_title] # Why array?
     else:
         return selected_items
 
 
-def collapse_all_params(params):
+def collapse_all_params(params, collapsing_functions):
     """ Iterate over params values and simplify them if possible """
     for key in collapsing_functions.keys():
         params[key] = collapsing_functions[key](params[key])
     return params
 
 
-def log_filters(params, logger):
-    collapse_all_params(params)
+def log_filters(params, collapsing_functions, logger):
+    collapse_all_params(params, collapsing_functions)
     del params['click']
     if datetime.datetime.strptime(params['end_date'], '%Y-%m-%d').date() == datetime.date.today():
         del params['end_date']

--- a/application/dash_application/utility/log_utils.py
+++ b/application/dash_application/utility/log_utils.py
@@ -9,7 +9,7 @@ compare = lambda s, t: Counter(s) == Counter(t)
 
 def collapse_if_all_selected(selected_items: List[str], all_items: List[str], all_title: str) -> List[str]:
     if compare(selected_items, all_items):
-        return [all_title] # Why array?
+        return [all_title] # Array for the sake of consistency 
     else:
         return selected_items
 

--- a/application/dash_application/utility/sidebar_utils.py
+++ b/application/dash_application/utility/sidebar_utils.py
@@ -50,7 +50,7 @@ def select_runs(all_runs_id: str, runs_id: str, runs: List[str]) -> \
 
 def run_range_input(run_range_id: str, start_date: str = None, end_date: str = None) -> html.Label:
     start = start_date if start_date else ALL_RUNS[pinery.column.RunsColumn.StartDate].min(skipna=True)
-    end = end_date if end_date else datetime.datetime.now()
+    end = end_date if end_date else datetime.date.today()
     return html.Label(["Filter by Run Start Date:",
                        html.Br(),
                        core.DatePickerRange(id=run_range_id,
@@ -219,7 +219,7 @@ def get_requested_run_date_range(last_string) -> List[str]:
     xdays = re.compile(r'(\d+)days').match(last_string)
     if xdays and xdays.group(1):
         days_ago = int(xdays.group(1))
-        end = datetime.datetime.now()
+        end = datetime.date.today()
         start = end - datetime.timedelta(days=days_ago)
         return [start, end]
     else:

--- a/application/dash_application/utility/sidebar_utils.py
+++ b/application/dash_application/utility/sidebar_utils.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import datetime
 import re
 import urllib.parse
@@ -94,9 +95,9 @@ def select_kits(all_kits_id: str, kits_id: str, kits: List[str]) -> \
 def select_library_designs(all_library_designs_id: str, library_designs_id:
         str, library_designs: List[str]) -> core.Loading:
     return select_with_select_all("All Library Designs",
-                                  all_library_designs_id, "Filter by Library "
-                                  "Designs", library_designs_id,
-                                  library_designs)
+                                  all_library_designs_id,
+                                  "Filter by Library Designs",
+                                  library_designs_id, library_designs)
 
 
 default_first_sort = [
@@ -232,3 +233,20 @@ def parse_run_date_range(query) -> List[str]:
         return get_requested_run_date_range(query_dict["last"][0])
     else:
         return [None, None]
+
+
+compare = lambda s, t: Counter(s) == Counter(t)
+
+
+def collapse_if_all_selected(selected_items: List[str], all_items: List[str], all_title: str) -> List[str]:
+    if compare(selected_items, all_items):
+        return [all_title]
+    else:
+        return selected_items
+
+
+def collapse_all_params(params, collapsing_funcs):
+    """ Iterate over params values and simplify them if possible """
+    for key in collapsing_funcs.keys():
+        params[key] = collapsing_funcs[key](params[key])
+    return params

--- a/application/dash_application/utility/sidebar_utils.py
+++ b/application/dash_application/utility/sidebar_utils.py
@@ -1,4 +1,3 @@
-from collections import Counter
 import datetime
 import re
 import urllib.parse
@@ -234,19 +233,3 @@ def parse_run_date_range(query) -> List[str]:
     else:
         return [None, None]
 
-
-compare = lambda s, t: Counter(s) == Counter(t)
-
-
-def collapse_if_all_selected(selected_items: List[str], all_items: List[str], all_title: str) -> List[str]:
-    if compare(selected_items, all_items):
-        return [all_title]
-    else:
-        return selected_items
-
-
-def collapse_all_params(params, collapsing_funcs):
-    """ Iterate over params values and simplify them if possible """
-    for key in collapsing_funcs.keys():
-        params[key] = collapsing_funcs[key](params[key])
-    return params

--- a/application/dash_application/views/single_lane_rna.py
+++ b/application/dash_application/views/single_lane_rna.py
@@ -15,6 +15,7 @@ from gsiqcetl.column import RnaSeqQcColumn as RnaColumn
 import pinery
 import logging
 import json
+import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -510,6 +511,8 @@ def init_callbacks(dash_app):
                        search_query):
         params = locals()
         del params['click']
+        if datetime.datetime.strptime(end_date, '%Y-%m-%d').date() == datetime.date.today():
+            del params['end_date']
         logger.info(json.dumps(params))
         
         if not runs and not instruments and not projects and not kits and not library_designs:

--- a/application/dash_application/views/single_lane_rna.py
+++ b/application/dash_application/views/single_lane_rna.py
@@ -11,6 +11,7 @@ from ..plot_builder import fill_in_colour_col, fill_in_shape_col, \
 from ..table_builder import table_tabs, cutoff_table_data
 from ..utility import df_manipulation as util
 from ..utility import sidebar_utils
+from ..utility import log_utils
 from gsiqcetl.column import RnaSeqQcColumn as RnaColumn
 import pinery
 import logging
@@ -509,11 +510,7 @@ def init_callbacks(dash_app):
                        start_date,
                        end_date,
                        search_query):
-        params = locals()
-        del params['click']
-        if datetime.datetime.strptime(end_date, '%Y-%m-%d').date() == datetime.date.today():
-            del params['end_date']
-        logger.info(json.dumps(params))
+        log_utils.log_filters(locals(), logger)
         
         if not runs and not instruments and not projects and not kits and not library_designs:
             df = EMPTY_RNA

--- a/application/dash_application/views/single_lane_rna.py
+++ b/application/dash_application/views/single_lane_rna.py
@@ -171,7 +171,7 @@ ALL_TISSUE_MATERIALS = RNA_DF[
     PINERY_COL.TissuePreparation].sort_values().unique()
 ALL_LIBRARY_DESIGNS = RNA_DF[
     PINERY_COL.LibrarySourceTemplateType].sort_values().unique()
-ALL_RUNS = RNA_DF[RNA_COL.Run].sort_values().unique()[::-1]  # reverse the list
+ALL_RUNS = RNA_DF[PINERY_COL.SequencerRunName].sort_values().unique()[::-1]  # reverse the list
 ALL_SAMPLES = RNA_DF[PINERY_COL.SampleName].sort_values().unique()
 
 # N.B. The keys in this object must match the argument names for
@@ -528,7 +528,7 @@ def init_callbacks(dash_app):
             df = RNA_DF
 
         if runs:
-            df = df[df[RNA_COL.Run].isin(runs)]
+            df = df[df[PINERY_COL.SequencerRunName].isin(runs)]
         if instruments:
             df = df[df[INSTRUMENT_COLS.ModelName].isin(instruments)]
         if projects:
@@ -538,7 +538,7 @@ def init_callbacks(dash_app):
         if library_designs:
             df = df[df[PINERY_COL.LibrarySourceTemplateType].isin(
                 library_designs)]
-        df = df[df[RNA_COL.Run].isin(sidebar_utils.runs_in_range(start_date, end_date))]
+        df = df[df[PINERY_COL.SequencerRunName].isin(sidebar_utils.runs_in_range(start_date, end_date))]
         sort_by = [first_sort, second_sort]
         df = df.sort_values(by=sort_by)
         df = fill_in_shape_col(df, shape_by, shape_or_colour_values)

--- a/application/dash_application/views/single_lane_rna.py
+++ b/application/dash_application/views/single_lane_rna.py
@@ -174,6 +174,16 @@ ALL_LIBRARY_DESIGNS = RNA_DF[
 ALL_RUNS = RNA_DF[RNA_COL.Run].sort_values().unique()[::-1]  # reverse the list
 ALL_SAMPLES = RNA_DF[PINERY_COL.SampleName].sort_values().unique()
 
+# N.B. The keys in this object must match the argument names for
+# the `update_pressed` function in the views.
+collapsing_functions = {
+    "projects": lambda selected: log_utils.collapse_if_all_selected(selected, ALL_PROJECTS, "all_projects"),
+    "runs": lambda selected: log_utils.collapse_if_all_selected(selected, ALL_RUNS, "all_runs"),
+    "kits": lambda selected: log_utils.collapse_if_all_selected(selected, ALL_KITS, "all_kits"),
+    "instruments": lambda selected: log_utils.collapse_if_all_selected(selected, ILLUMINA_INSTRUMENT_MODELS, "all_instruments"),
+    "library_designs": lambda selected: log_utils.collapse_if_all_selected(selected, ALL_LIBRARY_DESIGNS, "all_library_designs"),
+}
+
 shape_or_colour_values = {
     PINERY_COL.StudyTitle: ALL_PROJECTS,
     PINERY_COL.SequencerRunName: ALL_RUNS,
@@ -510,7 +520,7 @@ def init_callbacks(dash_app):
                        start_date,
                        end_date,
                        search_query):
-        log_utils.log_filters(locals(), logger)
+        log_utils.log_filters(locals(), collapsing_functions, logger)
         
         if not runs and not instruments and not projects and not kits and not library_designs:
             df = EMPTY_RNA

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -108,6 +108,15 @@ ALL_LIBRARY_DESIGNS = bamqc[
 ILLUMINA_INSTRUMENT_MODELS = util.get_illumina_instruments(bamqc)
 ALL_SAMPLES = bamqc[PINERY_COL.SampleName].sort_values().unique()
 
+# N.B. The keys in this object must match the argument names for
+# the `update_pressed` function in the views.
+collapsing_functions = {
+    "projects": lambda selected: log_utils.collapse_if_all_selected(selected, ALL_PROJECTS, "all_projects"),
+    "runs": lambda selected: log_utils.collapse_if_all_selected(selected, ALL_RUNS, "all_runs"),
+    "kits": lambda selected: log_utils.collapse_if_all_selected(selected, ALL_KITS, "all_kits"),
+    "instruments": lambda selected: log_utils.collapse_if_all_selected(selected, ILLUMINA_INSTRUMENT_MODELS, "all_instruments"),
+    "library_designs": lambda selected: log_utils.collapse_if_all_selected(selected, ALL_LIBRARY_DESIGNS, "all_library_designs"),
+}
 
 # Specify which columns to display in the DataTable
 first_col_set = [
@@ -399,7 +408,7 @@ def init_callbacks(dash_app):
             start_date,
             end_date,
             search_query):
-        log_utils.log_filters(locals(), logger)
+        log_utils.log_filters(locals(), collapsing_functions, logger)
 
         # Apply get selected runs
         if not runs and not instruments and not projects and not kits and not library_designs:

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -14,6 +14,7 @@ from gsiqcetl.column import BamQcColumn
 import pinery
 import logging
 import json
+import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -399,6 +400,8 @@ def init_callbacks(dash_app):
             search_query):
         params = locals()
         del params['click']
+        if datetime.datetime.strptime(end_date, '%Y-%m-%d').date() == datetime.date.today():
+            del params['end_date']
         logger.info(json.dumps(params))
 
         # Apply get selected runs

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -10,6 +10,7 @@ from ..plot_builder import generate, fill_in_shape_col, fill_in_colour_col, \
 from ..table_builder import table_tabs, cutoff_table_data
 from ..utility import df_manipulation as util
 from ..utility import sidebar_utils
+from ..utility import log_utils
 from gsiqcetl.column import BamQcColumn
 import pinery
 import logging
@@ -398,11 +399,7 @@ def init_callbacks(dash_app):
             start_date,
             end_date,
             search_query):
-        params = locals()
-        del params['click']
-        if datetime.datetime.strptime(end_date, '%Y-%m-%d').date() == datetime.date.today():
-            del params['end_date']
-        logger.info(json.dumps(params))
+        log_utils.log_filters(locals(), logger)
 
         # Apply get selected runs
         if not runs and not instruments and not projects and not kits and not library_designs:

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -99,7 +99,7 @@ def get_bamqc_data():
 
 # Build lists of attributes for sorting, shaping, and filtering on
 ALL_PROJECTS = bamqc[PINERY_COL.StudyTitle].sort_values().unique()
-ALL_RUNS = bamqc[BAMQC_COL.Run].sort_values().unique()[::-1] # reverse order
+ALL_RUNS = bamqc[PINERY_COL.SequencerRunName].sort_values().unique()[::-1] # reverse order
 ALL_KITS = bamqc[PINERY_COL.PrepKit].sort_values().unique()
 ALL_TISSUE_MATERIALS = bamqc[
     PINERY_COL.TissuePreparation].sort_values().unique()
@@ -417,7 +417,7 @@ def init_callbacks(dash_app):
             data = bamqc
 
         if runs:
-            data = data[data[BAMQC_COL.Run].isin(runs)]
+            data = data[data[PINERY_COL.SequencerRunName].isin(runs)]
         if instruments:
             data = data[data[INSTRUMENT_COLS.ModelName].isin(instruments)]
         if projects:
@@ -427,7 +427,7 @@ def init_callbacks(dash_app):
         if library_designs:
             data = data[data[PINERY_COL.LibrarySourceTemplateType].isin(
                 library_designs)]
-        data = data[data[BAMQC_COL.Run].isin(sidebar_utils.runs_in_range(start_date, end_date))]
+        data = data[data[PINERY_COL.SequencerRunName].isin(sidebar_utils.runs_in_range(start_date, end_date))]
         data = fill_in_shape_col(data, shapeby, shape_or_colour_values)
         data = fill_in_colour_col(data, colourby, shape_or_colour_values,
                                   searchsample)

--- a/application/dash_application/views/single_lane_wgs.py
+++ b/application/dash_application/views/single_lane_wgs.py
@@ -191,6 +191,16 @@ ALL_RUNS = WGS_DF[PINERY_COL.SequencerRunName].sort_values().unique()[
     ::-1]  # reverse the list
 ALL_SAMPLES = WGS_DF[PINERY_COL.SampleName].sort_values().unique()
 
+# N.B. The keys in this object must match the argument names for
+# the `update_pressed` function in the views.
+collapsing_functions = {
+    "projects": lambda selected: log_utils.collapse_if_all_selected(selected, ALL_PROJECTS, "all_projects"),
+    "runs": lambda selected: log_utils.collapse_if_all_selected(selected, ALL_RUNS, "all_runs"),
+    "kits": lambda selected: log_utils.collapse_if_all_selected(selected, ALL_KITS, "all_kits"),
+    "instruments": lambda selected: log_utils.collapse_if_all_selected(selected, ILLUMINA_INSTRUMENT_MODELS, "all_instruments"),
+    "library_designs": lambda selected: log_utils.collapse_if_all_selected(selected, ALL_LIBRARY_DESIGNS, "all_library_designs"),
+}
+
 shape_or_colour_values = {
     PINERY_COL.StudyTitle: ALL_PROJECTS,
     PINERY_COL.SequencerRunName: ALL_RUNS,
@@ -516,7 +526,7 @@ def init_callbacks(dash_app):
                        start_date,
                        end_date,
                        search_query):
-        log_utils.log_filters(locals(), logger)
+        log_utils.log_filters(locals(), collapsing_functions, logger)
 
         if not runs and not instruments and not projects and not kits and not library_designs:
             df = pd.DataFrame(columns=WGS_DF.columns)
@@ -591,3 +601,10 @@ def init_callbacks(dash_app):
     )
     def all_kits_requested(click):
         return [x for x in ALL_KITS]
+
+    @dash_app.callback(
+        Output(ids['library-designs-list'], 'value'),
+        [Input(ids['all-library-designs'], 'n_clicks')]
+    )
+    def all_library_designs_requested(click):
+        return [x for x in ALL_LIBRARY_DESIGNS]

--- a/application/dash_application/views/single_lane_wgs.py
+++ b/application/dash_application/views/single_lane_wgs.py
@@ -13,6 +13,7 @@ from ..plot_builder import fill_in_shape_col, fill_in_colour_col, \
 from ..table_builder import table_tabs, cutoff_table_data
 from ..utility import df_manipulation as util
 from ..utility import sidebar_utils
+from ..utility import log_utils
 import logging
 import json
 import datetime
@@ -515,12 +516,7 @@ def init_callbacks(dash_app):
                        start_date,
                        end_date,
                        search_query):
-        params = locals()
-        params = sidebar_utils.collapse_all_params(params, collapsing_functions)
-        del params['click']
-        if datetime.datetime.strptime(end_date, '%Y-%m-%d').date() == datetime.date.today():
-            del params['end_date']
-        logger.info(json.dumps(params))
+        log_utils.log_filters(locals(), logger)
 
         if not runs and not instruments and not projects and not kits and not library_designs:
             df = pd.DataFrame(columns=WGS_DF.columns)

--- a/application/dash_application/views/single_lane_wgs.py
+++ b/application/dash_application/views/single_lane_wgs.py
@@ -15,6 +15,7 @@ from ..utility import df_manipulation as util
 from ..utility import sidebar_utils
 import logging
 import json
+import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -516,6 +517,8 @@ def init_callbacks(dash_app):
                        search_query):
         params = locals()
         del params['click']
+        if datetime.datetime.strptime(end_date, '%Y-%m-%d').date() == datetime.date.today():
+            del params['end_date']
         logger.info(json.dumps(params))
 
         if not runs and not instruments and not projects and not kits and not library_designs:

--- a/application/dash_application/views/single_lane_wgs.py
+++ b/application/dash_application/views/single_lane_wgs.py
@@ -197,6 +197,16 @@ shape_or_colour_values = {
     PINERY_COL.TissuePreparation: ALL_TISSUE_MATERIALS
 }
 
+# N.B. The keys in this object must match the argument names for
+# the `update_pressed` function below.
+collapsing_functions = {
+    "projects": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_PROJECTS, "all_projects"),
+    "runs": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_RUNS, "all_runs"),
+    "kits": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_KITS, "all_kits"),
+    "instruments": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ILLUMINA_INSTRUMENT_MODELS, "all_instruments"),
+    "library_designs": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_LIBRARY_DESIGNS, "all_library_designs"),
+}
+
 # Add shape col to WG dataframe
 WGS_DF = fill_in_shape_col(WGS_DF, initial_shape_col, shape_or_colour_values)
 WGS_DF = fill_in_colour_col(WGS_DF, initial_colour_col, shape_or_colour_values)
@@ -516,6 +526,7 @@ def init_callbacks(dash_app):
                        end_date,
                        search_query):
         params = locals()
+        params = sidebar_utils.collapse_all_params(params, collapsing_functions)
         del params['click']
         if datetime.datetime.strptime(end_date, '%Y-%m-%d').date() == datetime.date.today():
             del params['end_date']

--- a/application/dash_application/views/single_lane_wgs.py
+++ b/application/dash_application/views/single_lane_wgs.py
@@ -197,16 +197,6 @@ shape_or_colour_values = {
     PINERY_COL.TissuePreparation: ALL_TISSUE_MATERIALS
 }
 
-# N.B. The keys in this object must match the argument names for
-# the `update_pressed` function below.
-collapsing_functions = {
-    "projects": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_PROJECTS, "all_projects"),
-    "runs": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_RUNS, "all_runs"),
-    "kits": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_KITS, "all_kits"),
-    "instruments": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ILLUMINA_INSTRUMENT_MODELS, "all_instruments"),
-    "library_designs": lambda selected: sidebar_utils.collapse_if_all_selected(selected, ALL_LIBRARY_DESIGNS, "all_library_designs"),
-}
-
 # Add shape col to WG dataframe
 WGS_DF = fill_in_shape_col(WGS_DF, initial_shape_col, shape_or_colour_values)
 WGS_DF = fill_in_colour_col(WGS_DF, initial_colour_col, shape_or_colour_values)


### PR DESCRIPTION
Convert end_date to date (vs datetime) and only log it if there has been a change to its value. This will improve our ability to aggregate logs to view trends in use of filters.