### PR TITLE
[GR-1011] Only plot samples that have QC data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and as of version 1.0.0, follows semantic versioning.
   * Filter logs now remove `end_date` if it is the current date
   * Filter logs now report `end_date` as a date rather than datetime
   * Filter logs now report `["all_runs"]` when all runs have been selected; etc for other dropdowns
+  * Pinery entries with no QC data are excluded from plots and data table
 ### Fixed
   * `nav_handler` and `content_handler` no longer throw exception on empty path
   * `Add All` button for Library Designs on WGS report now works

--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -123,7 +123,7 @@ def get_pinery_samples_from_active_projects():
 def df_with_pinery_samples(df: DataFrame, pinery_samples: DataFrame, ius_cols:
                            List[str]):
     """Do an left merge between the DataFrame and modern Pinery samples
-    data. Only samples in DataFrame will be kept."""
+    data. Only samples in QC DataFrame will be kept."""
     df = df.merge(
         pinery_samples,
         how="left",

--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -122,11 +122,11 @@ def get_pinery_samples_from_active_projects():
 
 def df_with_pinery_samples(df: DataFrame, pinery_samples: DataFrame, ius_cols:
                            List[str]):
-    """Do an outer merge between the DataFrame and modern Pinery samples
-    data."""
+    """Do an left merge between the DataFrame and modern Pinery samples
+    data. Only samples in DataFrame will be kept."""
     df = df.merge(
         pinery_samples,
-        how="right",
+        how="left",
         left_on=ius_cols,
         right_on=pinery_ius_columns
     )

--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -122,7 +122,7 @@ def get_pinery_samples_from_active_projects():
 
 def df_with_pinery_samples(df: DataFrame, pinery_samples: DataFrame, ius_cols:
                            List[str]):
-    """Do an left merge between the DataFrame and modern Pinery samples
+    """Do a left merge between the DataFrame and modern Pinery samples
     data. Only samples in QC DataFrame will be kept."""
     df = df.merge(
         pinery_samples,

--- a/application/dash_application/views/single_lane_wgs.py
+++ b/application/dash_application/views/single_lane_wgs.py
@@ -156,15 +156,16 @@ def get_wgs_data():
     ichorcna_df[special_cols["Purity"]] = round(
         ichorcna_df[ICHOR_COL.TumorFraction] * 100.0, 3)
 
-    # Join BamQC and Pinery data
-    wgs_df = util.df_with_pinery_samples(bamqc_df, pinery_samples,
-                                         util.bamqc_ius_columns)
+    # Join ichorCNA and BamQC data
+    wgs_df = bamqc_df.merge(
+        ichorcna_df, how="outer",
+        left_on=util.bamqc_ius_columns,
+        right_on=util.ichorcna_ius_columns
+    )
 
-    # Join ichorCNA and BamQC+Pinery data
-    wgs_df = wgs_df.merge(
-        ichorcna_df, how = "left",
-        left_on=util.pinery_ius_columns,
-        right_on=util.ichorcna_ius_columns)
+    # Join BamQC+ichorCNA and Pinery data
+    wgs_df = util.df_with_pinery_samples(wgs_df, pinery_samples,
+                                         util.bamqc_ius_columns)
 
     # Join df and instrument model
     wgs_df = util.df_with_instrument_model(wgs_df, PINERY_COL.SequencerRunName)


### PR DESCRIPTION
Currently, all samples in Pinery are plotted, even when they don't have any QC data. This has several problems:

- Filter drop down menus include Runs, Projects, Kits that have no data to plot (confusing to user)
- Slows down Dashi, as it has to handle many rows, but most of them hold no data
- Makes graphs mostly white space
![Screenshot from 2020-01-23 11-12-11](https://user-images.githubusercontent.com/37381890/73002694-6c711c00-3dd2-11ea-8266-8076f3630955.png)


Fix only keeps Pinery entries that have QC associated with them:
![Screenshot from 2020-01-23 11-14-00](https://user-images.githubusercontent.com/37381890/73002747-81e64600-3dd2-11ea-9d41-b5294ed435e4.png)

The DataTable now excludes samples with no QC data. I think that makes sense, as Dashi deals with QC, not with samples having a Pinery entry.