### PR TITLE
[GR-1015] Use tabs to bring tables to top of page

### DIFF
--- a/application/dash_application/views/call_ready_rna.py
+++ b/application/dash_application/views/call_ready_rna.py
@@ -262,52 +262,63 @@ def layout(query_string):
                                                initial[cutoff_rrna_contam]),
                 ]),
 
-                html.Div(className="seven columns", children=[
-                    core.Graph(
-                        id=ids["total-reads"],
-                        figure=generate_total_reads(df, util.ml_col,
-                            special_cols["Total Reads (Passed Filter)"],
-                            initial["colour_by"], initial["shape_by"], initial["shownames_val"],
-                            [(cutoff_pf_reads_label, initial[cutoff_pf_reads])])),
+                # Graphs + Tables tabs
+                html.Div(className="seven columns", 
+                children=[
+                    core.Tabs([
+                        # Graphs tab
+                        core.Tab(label="Graphs",
+                        children=[
+                            core.Graph(
+                                id=ids["total-reads"],
+                                figure=generate_total_reads(df, util.ml_col,
+                                    special_cols["Total Reads (Passed Filter)"],
+                                    initial["colour_by"], initial["shape_by"], initial["shownames_val"],
+                                    [(cutoff_pf_reads_label, initial[cutoff_pf_reads])])),
 
-                    core.Graph(
-                       id=ids["unique-reads"],
-                       figure=generate_unique_reads(df, initial)),
+                            core.Graph(
+                            id=ids["unique-reads"],
+                            figure=generate_unique_reads(df, initial)),
 
-                    core.Graph(
-                        id=ids["five-to-three-bias"],
-                        figure=generate_five_to_three(df, initial)),
+                            core.Graph(
+                                id=ids["five-to-three-bias"],
+                                figure=generate_five_to_three(df, initial)),
 
-                    core.Graph(
-                        id=ids["correct-read-strand"],
-                        figure=generate_correct_read_strand(df, initial)),
+                            core.Graph(
+                                id=ids["correct-read-strand"],
+                                figure=generate_correct_read_strand(df, initial)),
 
-                    core.Graph(
-                        id=ids["coding"],
-                        figure=generate_coding(df, initial)),
+                            core.Graph(
+                                id=ids["coding"],
+                                figure=generate_coding(df, initial)),
 
-                    core.Graph(
-                        id=ids["rrna-contam"],
-                        figure=generate_rrna_contam(df, initial)),
-
-                ])
-            ]),
-            table_tabs(
-                ids["failed-samples"],
-                ids["data-table"],
-                df,
-                rna_table_columns,
-                [
-                    (cutoff_pf_reads_label, special_cols["Total Reads (Passed Filter)"],
-                     initial[cutoff_pf_reads],
-                     (lambda row, col, cutoff: row[col] < cutoff)),
-                    (cutoff_rrna_contam_label, special_cols["% rRNA Contamination"],
-                     initial[cutoff_rrna_contam],
-                     (lambda row, col, cutoff: row[col] > cutoff)),
-                ]
-            )
-        ])
-    ])
+                            core.Graph(
+                                id=ids["rrna-contam"],
+                                figure=generate_rrna_contam(df, initial))
+                        ]),
+                        # Tables tab
+                        core.Tab(label="Tables",
+                        children=[
+                            table_tabs(
+                                ids["failed-samples"],
+                                ids["data-table"],
+                                df,
+                                rna_table_columns,
+                                [
+                                    (cutoff_pf_reads_label, special_cols["Total Reads (Passed Filter)"],
+                                    initial[cutoff_pf_reads],
+                                    (lambda row, col, cutoff: row[col] < cutoff)),
+                                    (cutoff_rrna_contam_label, special_cols["% rRNA Contamination"],
+                                    initial[cutoff_rrna_contam],
+                                    (lambda row, col, cutoff: row[col] > cutoff)),
+                                ]
+                            )
+                        ])
+                    ]) # End Tabs
+                ]) # End Div
+            ]) # End Div
+        ]) # End Div
+    ]) # End Loading
 
 
 def init_callbacks(dash_app):

--- a/application/dash_application/views/call_ready_ts_1.py
+++ b/application/dash_application/views/call_ready_ts_1.py
@@ -406,87 +406,97 @@ def layout(query_string):
                     #                            ids["duplicate-rate-max"], initial[cutoff_duplicate_rate]),
                 ]),
 
-                html.Div(className="seven columns", children=[
-                    core.Graph(
-                        id=ids["total-reads"],
-                        figure=generate_total_reads(df, util.ml_col,
-                            special_cols["Total Reads (Passed Filter)"],
-                            initial["colour_by"], initial["shape_by"], initial["shownames_val"],
-                            [(cutoff_pf_reads_normal_label, initial[cutoff_pf_reads_normal]),
-                             (cutoff_pf_reads_tumour_label, initial[cutoff_pf_reads_tumour])])),
+                # Graphs + Tables tabs
+                html.Div(className="seven columns", 
+                children=[
+                    core.Tabs([
+                        # Graphs tab
+                        core.Tab(label="Graphs",
+                        children=[
+                            core.Graph(
+                                id=ids["total-reads"],
+                                figure=generate_total_reads(df, util.ml_col,
+                                    special_cols["Total Reads (Passed Filter)"],
+                                    initial["colour_by"], initial["shape_by"], initial["shownames_val"],
+                                    [(cutoff_pf_reads_normal_label, initial[cutoff_pf_reads_normal]),
+                                    (cutoff_pf_reads_tumour_label, initial[cutoff_pf_reads_tumour])])),
 
-                    core.Graph(
-                       id=ids["unique-reads"],
-                       figure=generate_unique_reads(df, initial)),
+                            core.Graph(
+                            id=ids["unique-reads"],
+                            figure=generate_unique_reads(df, initial)),
 
-                    core.Graph(
-                        id=ids["mean-target-coverage"],
-                        figure=generate_mean_target_coverage(df, initial)),
+                            core.Graph(
+                                id=ids["mean-target-coverage"],
+                                figure=generate_mean_target_coverage(df, initial)),
 
-                    core.Graph(
-                        id=ids["callability"],
-                        figure=generate_callability(df, initial)),
+                            core.Graph(
+                                id=ids["callability"],
+                                figure=generate_callability(df, initial)),
 
-                    core.Graph(
-                        id=ids["mean-insert-size"],
-                        figure=generate_mean_insert_size(df, initial)),
+                            core.Graph(
+                                id=ids["mean-insert-size"],
+                                figure=generate_mean_insert_size(df, initial)),
 
-                    core.Graph(
-                        id=ids["hs-library-size"],
-                        figure=generate_hs_library_size(df, initial)),
+                            core.Graph(
+                                id=ids["hs-library-size"],
+                                figure=generate_hs_library_size(df, initial)),
 
-                    # core.Graph(
-                    #     id=ids["duplicate-rate"],
-                    #     figure=generate_duplicate_rate(df, initial)),
-                    #
-                    # core.Graph(
-                    #     id=ids["purity"],
-                    #     figure=generate_purity(df, initial)),
-                    #
-                    # core.Graph(
-                    #     id=ids["fraction-excluded"],
-                    #     figure=generate_fraction_excluded(df, initial)),
-                    #
-                    # core.Graph(
-                    #     id=ids["at-dropout"],
-                    #     figure=generate_at_dropout(df, initial)),
-                    #
-                    # core.Graph(
-                    #     id=ids["gc-dropout"],
-                    #     figure=generate_gc_dropout(df, initial)),
-
-                ])
-            ]),
-            table_tabs(
-                ids["failed-samples"],
-                ids["data-table"],
-                df,
-                ts_table_columns,
-                [
-                    (cutoff_pf_reads_tumour_label, special_cols["Total Reads (Passed Filter)"],
-                     initial[cutoff_pf_reads_tumour],
-                     (lambda row, col, cutoff: row[col] < cutoff and util.is_tumour(row))),
-                    (cutoff_pf_reads_normal_label, special_cols["Total Reads (Passed Filter)"],
-                     initial[cutoff_pf_reads_normal],
-                     (lambda row, col, cutoff: row[col] < cutoff and util.is_normal(row))),
-                    (cutoff_coverage_tumour_label, HSMETRICS_COL.MeanTargetCoverage,
-                     initial[cutoff_coverage_tumour],
-                     (lambda row, col, cutoff: row[col] < cutoff and util.is_tumour(row))),
-                    (cutoff_coverage_normal_label, HSMETRICS_COL.MeanTargetCoverage,
-                     initial[cutoff_coverage_normal],
-                    (lambda row, col, cutoff: row[col] < cutoff and util.is_normal(row))),
-                    (cutoff_callability_label, special_cols["Callability (14x/8x)"],
-                     initial[cutoff_callability],
-                     (lambda row, col, cutoff: row[col] < cutoff)),
-                    (cutoff_insert_mean_label, BAMQC_COL.InsertMean, initial[cutoff_insert_mean],
-                     (lambda row, col, cutoff: row[col] < cutoff)),
-                    # (cutoff_duplicate_rate_label, BAMQC_COL.MarkDuplicates_PERCENT_DUPLICATION,
-                    #  initial[cutoff_duplicate_rate], (lambda row, col, cutoff: row[col] > cutoff)),
-                ]
-            )
-        ])
-    ])
-
+                            # core.Graph(
+                            #     id=ids["duplicate-rate"],
+                            #     figure=generate_duplicate_rate(df, initial)),
+                            #
+                            # core.Graph(
+                            #     id=ids["purity"],
+                            #     figure=generate_purity(df, initial)),
+                            #
+                            # core.Graph(
+                            #     id=ids["fraction-excluded"],
+                            #     figure=generate_fraction_excluded(df, initial)),
+                            #
+                            # core.Graph(
+                            #     id=ids["at-dropout"],
+                            #     figure=generate_at_dropout(df, initial)),
+                            #
+                            # core.Graph(
+                            #     id=ids["gc-dropout"],
+                            #     figure=generate_gc_dropout(df, initial)),
+                        ]),
+                        # Tables tab
+                        core.Tab(label="Tables",
+                        children=[
+                            table_tabs(
+                                ids["failed-samples"],
+                                ids["data-table"],
+                                df,
+                                ts_table_columns,
+                                [
+                                    (cutoff_pf_reads_tumour_label, special_cols["Total Reads (Passed Filter)"],
+                                    initial[cutoff_pf_reads_tumour],
+                                    (lambda row, col, cutoff: row[col] < cutoff and util.is_tumour(row))),
+                                    (cutoff_pf_reads_normal_label, special_cols["Total Reads (Passed Filter)"],
+                                    initial[cutoff_pf_reads_normal],
+                                    (lambda row, col, cutoff: row[col] < cutoff and util.is_normal(row))),
+                                    (cutoff_coverage_tumour_label, HSMETRICS_COL.MeanTargetCoverage,
+                                    initial[cutoff_coverage_tumour],
+                                    (lambda row, col, cutoff: row[col] < cutoff and util.is_tumour(row))),
+                                    (cutoff_coverage_normal_label, HSMETRICS_COL.MeanTargetCoverage,
+                                    initial[cutoff_coverage_normal],
+                                    (lambda row, col, cutoff: row[col] < cutoff and util.is_normal(row))),
+                                    (cutoff_callability_label, special_cols["Callability (14x/8x)"],
+                                    initial[cutoff_callability],
+                                    (lambda row, col, cutoff: row[col] < cutoff)),
+                                    (cutoff_insert_mean_label, BAMQC_COL.InsertMean, initial[cutoff_insert_mean],
+                                    (lambda row, col, cutoff: row[col] < cutoff)),
+                                    # (cutoff_duplicate_rate_label, BAMQC_COL.MarkDuplicates_PERCENT_DUPLICATION,
+                                    #  initial[cutoff_duplicate_rate], (lambda row, col, cutoff: row[col] > cutoff)),
+                                ]
+                            )
+                        ])
+                    ]) # End Tabs
+                ]) # End Div
+            ]) # End Div
+        ]) # End Div
+    ]) # End Loading
 
 def init_callbacks(dash_app):
     @dash_app.callback(

--- a/application/dash_application/views/call_ready_ts_2.py
+++ b/application/dash_application/views/call_ready_ts_2.py
@@ -406,87 +406,97 @@ def layout(query_string):
                                                ids["duplicate-rate-max"], initial[cutoff_duplicate_rate]),
                 ]),
 
-                html.Div(className="seven columns", children=[
-                    # core.Graph(
-                    #     id=ids["total-reads"],
-                    #     figure=generate_total_reads(df, util.ml_col,
-                    #         special_cols["Total Reads (Passed Filter)"],
-                    #         initial["colour_by"], initial["shape_by"], initial["shownames_val"],
-                    #         [(cutoff_pf_reads_normal_label, initial[cutoff_pf_reads_normal]),
-                    #          (cutoff_pf_reads_tumour_label, initial[cutoff_pf_reads_tumour])])),
-                    #
-                    # core.Graph(
-                    #    id=ids["unique-reads"],
-                    #    figure=generate_unique_reads(df, initial)),
-                    #
-                    # core.Graph(
-                    #     id=ids["mean-target-coverage"],
-                    #     figure=generate_mean_target_coverage(df, initial)),
-                    #
-                    # core.Graph(
-                    #     id=ids["callability"],
-                    #     figure=generate_callability(df, initial)),
-                    #
-                    # core.Graph(
-                    #     id=ids["mean-insert-size"],
-                    #     figure=generate_mean_insert_size(df, initial)),
-                    #
-                    # core.Graph(
-                    #     id=ids["hs-library-size"],
-                    #     figure=generate_hs_library_size(df, initial)),
+		        # Graphs + Tables tabs
+                html.Div(className="seven columns", 
+                children=[
+                    core.Tabs([
+                        # Graphs tab
+                        core.Tab(label="Graphs",
+                        children=[
+                            # core.Graph(
+                            #     id=ids["total-reads"],
+                            #     figure=generate_total_reads(df, util.ml_col,
+                            #         special_cols["Total Reads (Passed Filter)"],
+                            #         initial["colour_by"], initial["shape_by"], initial["shownames_val"],
+                            #         [(cutoff_pf_reads_normal_label, initial[cutoff_pf_reads_normal]),
+                            #          (cutoff_pf_reads_tumour_label, initial[cutoff_pf_reads_tumour])])),
+                            #
+                            # core.Graph(
+                            #    id=ids["unique-reads"],
+                            #    figure=generate_unique_reads(df, initial)),
+                            #
+                            # core.Graph(
+                            #     id=ids["mean-target-coverage"],
+                            #     figure=generate_mean_target_coverage(df, initial)),
+                            #
+                            # core.Graph(
+                            #     id=ids["callability"],
+                            #     figure=generate_callability(df, initial)),
+                            #
+                            # core.Graph(
+                            #     id=ids["mean-insert-size"],
+                            #     figure=generate_mean_insert_size(df, initial)),
+                            #
+                            # core.Graph(
+                            #     id=ids["hs-library-size"],
+                            #     figure=generate_hs_library_size(df, initial)),
 
-                    core.Graph(
-                        id=ids["duplicate-rate"],
-                        figure=generate_duplicate_rate(df, initial)),
+                            core.Graph(
+                                id=ids["duplicate-rate"],
+                                figure=generate_duplicate_rate(df, initial)),
 
-                    core.Graph(
-                        id=ids["purity"],
-                        figure=generate_purity(df, initial)),
+                            core.Graph(
+                                id=ids["purity"],
+                                figure=generate_purity(df, initial)),
 
-                    core.Graph(
-                        id=ids["fraction-excluded"],
-                        figure=generate_fraction_excluded(df, initial)),
+                            core.Graph(
+                                id=ids["fraction-excluded"],
+                                figure=generate_fraction_excluded(df, initial)),
 
-                    core.Graph(
-                        id=ids["at-dropout"],
-                        figure=generate_at_dropout(df, initial)),
+                            core.Graph(
+                                id=ids["at-dropout"],
+                                figure=generate_at_dropout(df, initial)),
 
-                    core.Graph(
-                        id=ids["gc-dropout"],
-                        figure=generate_gc_dropout(df, initial)),
-
-                ])
-            ]),
-            table_tabs(
-                ids["failed-samples"],
-                ids["data-table"],
-                df,
-                ts_table_columns,
-                [
-                    # (cutoff_pf_reads_tumour_label, special_cols["Total Reads (Passed Filter)"],
-                    #  initial[cutoff_pf_reads_tumour],
-                    #  (lambda row, col, cutoff: row[col] < cutoff and util.is_tumour(row))),
-                    # (cutoff_pf_reads_normal_label, special_cols["Total Reads (Passed Filter)"],
-                    #  initial[cutoff_pf_reads_normal],
-                    #  (lambda row, col, cutoff: row[col] < cutoff and util.is_normal(row))),
-                    # (cutoff_coverage_tumour_label, HSMETRICS_COL.MeanTargetCoverage,
-                    #  initial[cutoff_coverage_tumour],
-                    #  (lambda row, col, cutoff: row[col] < cutoff and util.is_tumour(row))),
-                    # (cutoff_coverage_normal_label, HSMETRICS_COL.MeanTargetCoverage,
-                    #  initial[cutoff_coverage_normal],
-                    # (lambda row, col, cutoff: row[col] < cutoff and util.is_normal(row))),
-                    # (cutoff_callability_label, special_cols["Callability (14x/8x)"],
-                    #  initial[cutoff_callability],
-                    #  (lambda row, col, cutoff: row[col] < cutoff)),
-                    # (cutoff_insert_mean_label, BAMQC_COL.InsertMean, initial[cutoff_insert_mean],
-                    #  (lambda row, col, cutoff: row[col] < cutoff)),
-                    (cutoff_duplicate_rate_label, BAMQC_COL.MarkDuplicates_PERCENT_DUPLICATION,
-                     initial[cutoff_duplicate_rate], (lambda row, col, cutoff: row[col] > cutoff)),
-                ]
-            )
-        ])
-    ])
-
+                            core.Graph(
+                                id=ids["gc-dropout"],
+                                figure=generate_gc_dropout(df, initial)),
+                        ]),
+                        # Tables tab
+                        core.Tab(label="Tables",
+                        children=[
+                            table_tabs(
+                                ids["failed-samples"],
+                                ids["data-table"],
+                                df,
+                                ts_table_columns,
+                                [
+                                    # (cutoff_pf_reads_tumour_label, special_cols["Total Reads (Passed Filter)"],
+                                    #  initial[cutoff_pf_reads_tumour],
+                                    #  (lambda row, col, cutoff: row[col] < cutoff and util.is_tumour(row))),
+                                    # (cutoff_pf_reads_normal_label, special_cols["Total Reads (Passed Filter)"],
+                                    #  initial[cutoff_pf_reads_normal],
+                                    #  (lambda row, col, cutoff: row[col] < cutoff and util.is_normal(row))),
+                                    # (cutoff_coverage_tumour_label, HSMETRICS_COL.MeanTargetCoverage,
+                                    #  initial[cutoff_coverage_tumour],
+                                    #  (lambda row, col, cutoff: row[col] < cutoff and util.is_tumour(row))),
+                                    # (cutoff_coverage_normal_label, HSMETRICS_COL.MeanTargetCoverage,
+                                    #  initial[cutoff_coverage_normal],
+                                    # (lambda row, col, cutoff: row[col] < cutoff and util.is_normal(row))),
+                                    # (cutoff_callability_label, special_cols["Callability (14x/8x)"],
+                                    #  initial[cutoff_callability],
+                                    #  (lambda row, col, cutoff: row[col] < cutoff)),
+                                    # (cutoff_insert_mean_label, BAMQC_COL.InsertMean, initial[cutoff_insert_mean],
+                                    #  (lambda row, col, cutoff: row[col] < cutoff)),
+                                    (cutoff_duplicate_rate_label, BAMQC_COL.MarkDuplicates_PERCENT_DUPLICATION,
+                                    initial[cutoff_duplicate_rate], (lambda row, col, cutoff: row[col] > cutoff)),
+                                ]
+                            )
+                        ])
+                    ]) # End Tabs
+                ]) # End Div
+            ]) # End Div
+        ]) # End Div
+    ]) # End Loading
 
 def init_callbacks(dash_app):
     @dash_app.callback(

--- a/application/dash_application/views/call_ready_wgs.py
+++ b/application/dash_application/views/call_ready_wgs.py
@@ -366,87 +366,93 @@ def layout(query_string):
                         ids["cutoff-duplicate-rate"], initial[cutoff_duplicate_rate]),
                 ]),
 
-                html.Div(className="seven columns", children=[
-                    # TODO: move this below total-reads once we've figured out
-                    # what to do about WebGL contexts.
-                    # Right now the data is suspect so it's ok if it doesn't
-                    # display happily.
-                    core.Graph(
-                        id=ids["unique-reads"],
-                        figure=generate_unique_reads(df, initial)
-                    ),
-                    core.Graph(
-                        id=ids["total-reads"],
-                        figure=generate_total_reads(
-                            df, util.ml_col,
-                            special_cols["Total Reads (Passed Filter)"],
-                            initial["colour_by"], initial["shape_by"],
-                            initial["shownames_val"],
-                            [(cutoff_pf_reads_tumour_label, initial[cutoff_pf_reads_tumour]),
-                             (cutoff_pf_reads_normal_label, initial[cutoff_pf_reads_normal])]
-                        )
-                    ),
-                    core.Graph(
-                        id=ids["mean-coverage"],
-                        figure=generate_deduplicated_coverage(df, initial)
-                    ),
-                    core.Graph(
-                        id=ids["callability"],
-                        figure=generate_callability(df, initial)
-                    ),
-                    core.Graph(
-                        id=ids["mean-insert"],
-                        figure=generate_mean_insert_size(df, initial)
-                    ),
-                    core.Graph(
-                        id=ids["duplicate-rate"],
-                        figure=generate_duplicate_rate(df, initial)
-                    ),
-                    core.Graph(
-                        id=ids["purity"],
-                        figure=generate_purity(df, initial)
-                    ),
-                    core.Graph(
-                        id=ids["ploidy"],
-                        figure=generate_ploidy(df, initial)
-                    ),
-                    core.Graph(
-                        id=ids["unmapped-reads"],
-                        figure=generate_unmapped_reads(df, initial)
-                    ),
-                    
-            ])
-        ]),
-        table_tabs(
-            ids["failed-samples"],
-            ids["data-table"],
-            df,
-            wgs_table_columns,
-            [
-                (cutoff_pf_reads_tumour_label, special_cols["Total Reads (Passed Filter)"],
-                 initial[cutoff_pf_reads_tumour],
-                 (lambda row, col, cutoff: row[col] < cutoff and util.is_tumour(row))),
-                (cutoff_pf_reads_normal_label, special_cols["Total Reads (Passed Filter)"],
-                 initial[cutoff_pf_reads_normal],
-                 (lambda row, col, cutoff: row[col] < cutoff and util.is_normal(row))),
-                (cutoff_coverage_tumour_label, BAMQC_COL.CoverageDeduplicated,
-                 initial[cutoff_coverage_tumour],
-                 (lambda row, col, cutoff: row[col] < cutoff and util.is_tumour(row))),
-                (cutoff_coverage_normal_label, BAMQC_COL.CoverageDeduplicated,
-                 initial[cutoff_coverage_normal],
-                 (lambda row, col, cutoff: row[col] < cutoff and util.is_normal(row))),
-                (cutoff_callability_label, special_cols["Percent Callability"],
-                 initial[cutoff_callability],
-                 (lambda row, col, cutoff: row[col] < cutoff)),
-                (cutoff_insert_mean_label, BAMQC_COL.InsertMean, initial[cutoff_insert_mean],
-                 (lambda row, col, cutoff: row[col] < cutoff)),
-                (cutoff_duplicate_rate_label, BAMQC_COL.MarkDuplicates_PERCENT_DUPLICATION,
-                 initial[cutoff_duplicate_rate], (lambda row, col, cutoff: row[col] > cutoff)),
-
-            ]
-        )
-    ])
-])
+                # Graphs + Tables tabs
+                html.Div(className="seven columns", 
+                children=[
+                    core.Tabs([
+                        # Graphs tab
+                        core.Tab(label="Graphs",
+                        children=[
+                            core.Graph(
+                                id=ids["unique-reads"],
+                                figure=generate_unique_reads(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["total-reads"],
+                                figure=generate_total_reads(
+                                    df, util.ml_col,
+                                    special_cols["Total Reads (Passed Filter)"],
+                                    initial["colour_by"], initial["shape_by"],
+                                    initial["shownames_val"],
+                                    [(cutoff_pf_reads_tumour_label, initial[cutoff_pf_reads_tumour]),
+                                    (cutoff_pf_reads_normal_label, initial[cutoff_pf_reads_normal])]
+                                )
+                            ),
+                            core.Graph(
+                                id=ids["mean-coverage"],
+                                figure=generate_deduplicated_coverage(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["callability"],
+                                figure=generate_callability(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["mean-insert"],
+                                figure=generate_mean_insert_size(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["duplicate-rate"],
+                                figure=generate_duplicate_rate(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["purity"],
+                                figure=generate_purity(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["ploidy"],
+                                figure=generate_ploidy(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["unmapped-reads"],
+                                figure=generate_unmapped_reads(df, initial)
+                            )
+                        ]),
+                        # Tables tab
+                        core.Tab(label="Tables",
+                        children=[
+                            table_tabs(
+                                ids["failed-samples"],
+                                ids["data-table"],
+                                df,
+                                wgs_table_columns,
+                                [
+                                    (cutoff_pf_reads_tumour_label, special_cols["Total Reads (Passed Filter)"],
+                                    initial[cutoff_pf_reads_tumour],
+                                    (lambda row, col, cutoff: row[col] < cutoff and util.is_tumour(row))),
+                                    (cutoff_pf_reads_normal_label, special_cols["Total Reads (Passed Filter)"],
+                                    initial[cutoff_pf_reads_normal],
+                                    (lambda row, col, cutoff: row[col] < cutoff and util.is_normal(row))),
+                                    (cutoff_coverage_tumour_label, BAMQC_COL.CoverageDeduplicated,
+                                    initial[cutoff_coverage_tumour],
+                                    (lambda row, col, cutoff: row[col] < cutoff and util.is_tumour(row))),
+                                    (cutoff_coverage_normal_label, BAMQC_COL.CoverageDeduplicated,
+                                    initial[cutoff_coverage_normal],
+                                    (lambda row, col, cutoff: row[col] < cutoff and util.is_normal(row))),
+                                    (cutoff_callability_label, special_cols["Percent Callability"],
+                                    initial[cutoff_callability],
+                                    (lambda row, col, cutoff: row[col] < cutoff)),
+                                    (cutoff_insert_mean_label, BAMQC_COL.InsertMean, initial[cutoff_insert_mean],
+                                    (lambda row, col, cutoff: row[col] < cutoff)),
+                                    (cutoff_duplicate_rate_label, BAMQC_COL.MarkDuplicates_PERCENT_DUPLICATION,
+                                    initial[cutoff_duplicate_rate], (lambda row, col, cutoff: row[col] > cutoff)),
+                                ]
+                            )
+                        ])
+                    ]) # End Tabs
+                ]) # End Div
+            ]) # End Div
+        ]) # End Div
+    ]) # End Loading
 
 
 def init_callbacks(dash_app):

--- a/application/dash_application/views/single_lane_rna.py
+++ b/application/dash_application/views/single_lane_rna.py
@@ -381,69 +381,78 @@ def layout(query_string):
                     ids["rrna-contamination-cutoff"], initial[cutoff_rrna]),
             ]),
 
-            # Graphs
-            html.Div(className="seven columns",  children=[
-                 core.Graph(
-                     id=ids["total-reads"],
-                     figure=generate_total_reads(
-                         df,
-                         PINERY_COL.SampleName,
-                         special_cols["Total Reads (Passed Filter)"],
-                         initial["colour_by"],
-                         initial["shape_by"],
-                         initial["shownames_val"],
-                         [(cutoff_pf_reads_label, initial[cutoff_pf_reads])])
-                 ),
-                 core.Graph(
-                     id=ids["unique-reads"],
-                     figure=generate_unique_reads(df, initial)
-                 ),
-                 core.Graph(
-                     id=ids["5-to-3-prime-bias"],
-                     figure=generate_five_to_three(df,
-                                                   initial)
-                 ),
-                 core.Graph(
-                     id=ids["correct-read-strand"],
-                     figure=generate_correct_read_strand(df,
-                                                         initial)
-                 ),
-                 core.Graph(
-                     id=ids["coding"],
-                     figure=generate_coding(df, initial)
-                 ),
-                 core.Graph(
-                     id=ids["rrna-contam"],
-                     figure=generate_rrna_contam(df, initial)
-                 ),
-                 core.Graph(
-                     id=ids["dv200"],
-                     figure=generate_dv200(df, initial)
-                 ),
-                 core.Graph(
-                     id=ids["rin"],
-                     figure=generate_rin(df, initial)
-                 ),
-             ]),
-
-            # Tables
-            table_tabs(
-                ids["failed-samples"],
-                ids["data-table"],
-                df,
-                rnaseqqc_table_columns,
-                [
-                    (cutoff_pf_reads_label,
-                     special_cols["Total Reads (Passed Filter)"], initial[cutoff_pf_reads],
-                     (lambda row, col, cutoff: row[col] < cutoff)),
-                    (cutoff_rrna_label,
-                     RNA_COL.rRNAContaminationreadsaligned, initial[cutoff_rrna],
-                     (lambda row, col, cutoff: row[col] > cutoff))
-                ]
-            )
-        ])
-    ]),
-])
+		        # Graphs + Tables tabs
+                html.Div(className="seven columns", 
+                children=[
+                    core.Tabs([
+                        # Graphs tab
+                        core.Tab(label="Graphs",
+                        children=[
+                            core.Graph(
+                                id=ids["total-reads"],
+                                figure=generate_total_reads(
+                                    df,
+                                    PINERY_COL.SampleName,
+                                    special_cols["Total Reads (Passed Filter)"],
+                                    initial["colour_by"],
+                                    initial["shape_by"],
+                                    initial["shownames_val"],
+                                    [(cutoff_pf_reads_label, initial[cutoff_pf_reads])])
+                            ),
+                            core.Graph(
+                                id=ids["unique-reads"],
+                                figure=generate_unique_reads(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["5-to-3-prime-bias"],
+                                figure=generate_five_to_three(df,
+                                                            initial)
+                            ),
+                            core.Graph(
+                                id=ids["correct-read-strand"],
+                                figure=generate_correct_read_strand(df,
+                                                                    initial)
+                            ),
+                            core.Graph(
+                                id=ids["coding"],
+                                figure=generate_coding(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["rrna-contam"],
+                                figure=generate_rrna_contam(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["dv200"],
+                                figure=generate_dv200(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["rin"],
+                                figure=generate_rin(df, initial)
+                            ),
+                        ]),
+                        # Tables tab
+                        core.Tab(label="Tables",
+                        children=[
+                            table_tabs(
+                                ids["failed-samples"],
+                                ids["data-table"],
+                                df,
+                                rnaseqqc_table_columns,
+                                [
+                                    (cutoff_pf_reads_label,
+                                    special_cols["Total Reads (Passed Filter)"], initial[cutoff_pf_reads],
+                                    (lambda row, col, cutoff: row[col] < cutoff)),
+                                    (cutoff_rrna_label,
+                                    RNA_COL.rRNAContaminationreadsaligned, initial[cutoff_rrna],
+                                    (lambda row, col, cutoff: row[col] > cutoff))
+                                ]
+                            )
+                        ])
+                    ]) # End Tabs
+                ]) # End Div
+            ]) # End Div
+        ]) # End Div
+    ]) # End Loading
 
 
 def init_callbacks(dash_app):

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -298,7 +298,7 @@ def layout(query_string):
 
                 # Graphs
                 html.Div(className="seven columns", children=[core.Tabs( children=[
-                    core.Tab(label="test tab 1",
+                    core.Tab(label="Graphs",
                     children=[html.Div(
                     children=[
                         core.Graph(id=ids['total-reads'],
@@ -325,7 +325,7 @@ def layout(query_string):
                         )
                     ]),
                 ]),
-                    core.Tab(label="test tab 2",
+                    core.Tab(label="Tables",
                     children=[table_tabs(
                     ids["failed-samples"],
                     ids["data-table"],

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -296,52 +296,62 @@ def layout(query_string):
                         ids['insert-size-mean-cutoff'], initial[cutoff_insert_mean]),
                 ]),
 
-                # Graphs
-                html.Div(className="seven columns", children=[core.Tabs( children=[
-                    core.Tab(label="Graphs",
-                    children=[html.Div(
-                    children=[
-                        core.Graph(id=ids['total-reads'],
-                            figure=generate_total_reads(
+                # Graphs + Tables tabs
+                html.Div(className="seven columns", 
+                children=[
+                    core.Tabs([
+                        # Graphs tab
+                        core.Tab(label="Graphs",
+                        children=[
+                            html.Div(
+                                children=[
+                                    core.Graph(id=ids['total-reads'],
+                                        figure=generate_total_reads(
+                                            df,
+                                            PINERY_COL.SampleName,
+                                            special_cols["Total Reads (Passed Filter)"],
+                                            initial["colour_by"],
+                                            initial["shape_by"],
+                                            initial["shownames_val"],
+                                            [(cutoff_pf_reads_label, initial[cutoff_pf_reads])])
+                                    ),
+                                    core.Graph(id=ids['unmapped-reads'],
+                                        figure=generate_unmapped_reads(df, initial)
+                                    ),
+                                    core.Graph(id=ids['non-primary-reads'],
+                                        figure=generate_nonprimary_reads(df, initial)
+                                    ),
+                                    core.Graph(id=ids['on-target-reads'],
+                                        figure=generate_on_target_reads(df,initial)
+                                    ),
+                                    core.Graph(id=ids['mean-insert-size'],
+                                        figure=generate_mean_insert_size(df, initial)
+                                    )
+                                ]
+                            ),
+                        ]),
+                        # Tables tab
+                        core.Tab(label="Tables",
+                        children=[
+                            table_tabs(
+                                ids["failed-samples"],
+                                ids["data-table"],
                                 df,
-                                PINERY_COL.SampleName,
-                                special_cols["Total Reads (Passed Filter)"],
-                                initial["colour_by"],
-                                initial["shape_by"],
-                                initial["shownames_val"],
-                                [(cutoff_pf_reads_label, initial[cutoff_pf_reads])])
-                        ),
-                        core.Graph(id=ids['unmapped-reads'],
-                            figure=generate_unmapped_reads(df, initial)
-                        ),
-                        core.Graph(id=ids['non-primary-reads'],
-                            figure=generate_nonprimary_reads(df, initial)
-                        ),
-                        core.Graph(id=ids['on-target-reads'],
-                            figure=generate_on_target_reads(df,initial)
-                        ),
-                        core.Graph(id=ids['mean-insert-size'],
-                            figure=generate_mean_insert_size(df, initial)
-                        )
-                    ]),
-                ]),
-                    core.Tab(label="Tables",
-                    children=[table_tabs(
-                    ids["failed-samples"],
-                    ids["data-table"],
-                    df,
-                    ex_table_columns,
-                    [
-                        (cutoff_insert_mean_label, BAMQC_COL.InsertMean, initial[cutoff_insert_mean],
-                         (lambda row, col, cutoff: row[col] < cutoff)),
-                        (cutoff_pf_reads_label,
-                        special_cols["Total Reads (Passed Filter)"], initial[cutoff_pf_reads],
-                        (lambda row, col, cutoff: row[col] < cutoff)),
-                    ]
-                )])
-                ]) ])      
+                                ex_table_columns,
+                                [
+                                    (cutoff_insert_mean_label, BAMQC_COL.InsertMean, initial[cutoff_insert_mean],
+                                    (lambda row, col, cutoff: row[col] < cutoff)),
+                                    (cutoff_pf_reads_label,
+                                    special_cols["Total Reads (Passed Filter)"], initial[cutoff_pf_reads],
+                                    (lambda row, col, cutoff: row[col] < cutoff)),
+                                ]
+                            )
+                        ])
+                    ])
+                ])      
+            ])
         ])
-])])
+    ])
 
 
 def init_callbacks(dash_app):

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -311,7 +311,8 @@ def layout(query_string):
                                     initial["colour_by"],
                                     initial["shape_by"],
                                     initial["shownames_val"],
-                                    [(cutoff_pf_reads_label, initial[cutoff_pf_reads])])
+                                    [(cutoff_pf_reads_label, initial[cutoff_pf_reads])]
+                                )
                             ),
                             core.Graph(id=ids['unmapped-reads'],
                                 figure=generate_unmapped_reads(df, initial)

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -347,11 +347,11 @@ def layout(query_string):
                                 ]
                             )
                         ])
-                    ])
-                ])      
-            ])
-        ])
-    ])
+                    ]) # End Tabs
+                ]) # End Div
+            ]) # End Div
+        ]) # End Div
+    ]) # End Loading
 
 
 def init_callbacks(dash_app):

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -297,9 +297,9 @@ def layout(query_string):
                 ]),
 
                 # Graphs
-                core.Tabs(className='seven columns', children=[
+                html.Div(className="seven columns", children=[core.Tabs( children=[
                     core.Tab(label="test tab 1",
-                    children=[html.Div(className='seven columns',
+                    children=[html.Div(
                     children=[
                         core.Graph(id=ids['total-reads'],
                             figure=generate_total_reads(
@@ -339,7 +339,7 @@ def layout(query_string):
                         (lambda row, col, cutoff: row[col] < cutoff)),
                     ]
                 )])
-                ])       
+                ]) ])      
         ])
 ])])
 

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -297,7 +297,9 @@ def layout(query_string):
                 ]),
 
                 # Graphs
-                html.Div(className='seven columns',
+                core.Tabs(className='seven columns', children=[
+                    core.Tab(label="test tab 1",
+                    children=[html.Div(className='seven columns',
                     children=[
                         core.Graph(id=ids['total-reads'],
                             figure=generate_total_reads(
@@ -323,9 +325,8 @@ def layout(query_string):
                         )
                     ]),
                 ]),
-
-                # Tables
-                table_tabs(
+                    core.Tab(label="test tab 2",
+                    children=[table_tabs(
                     ids["failed-samples"],
                     ids["data-table"],
                     df,
@@ -337,9 +338,10 @@ def layout(query_string):
                         special_cols["Total Reads (Passed Filter)"], initial[cutoff_pf_reads],
                         (lambda row, col, cutoff: row[col] < cutoff)),
                     ]
-                )
-        ]),
-])
+                )])
+                ])       
+        ])
+])])
 
 
 def init_callbacks(dash_app):

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -303,32 +303,28 @@ def layout(query_string):
                         # Graphs tab
                         core.Tab(label="Graphs",
                         children=[
-                            html.Div(
-                                children=[
-                                    core.Graph(id=ids['total-reads'],
-                                        figure=generate_total_reads(
-                                            df,
-                                            PINERY_COL.SampleName,
-                                            special_cols["Total Reads (Passed Filter)"],
-                                            initial["colour_by"],
-                                            initial["shape_by"],
-                                            initial["shownames_val"],
-                                            [(cutoff_pf_reads_label, initial[cutoff_pf_reads])])
-                                    ),
-                                    core.Graph(id=ids['unmapped-reads'],
-                                        figure=generate_unmapped_reads(df, initial)
-                                    ),
-                                    core.Graph(id=ids['non-primary-reads'],
-                                        figure=generate_nonprimary_reads(df, initial)
-                                    ),
-                                    core.Graph(id=ids['on-target-reads'],
-                                        figure=generate_on_target_reads(df,initial)
-                                    ),
-                                    core.Graph(id=ids['mean-insert-size'],
-                                        figure=generate_mean_insert_size(df, initial)
-                                    )
-                                ]
+                            core.Graph(id=ids['total-reads'],
+                                figure=generate_total_reads(
+                                    df,
+                                    PINERY_COL.SampleName,
+                                    special_cols["Total Reads (Passed Filter)"],
+                                    initial["colour_by"],
+                                    initial["shape_by"],
+                                    initial["shownames_val"],
+                                    [(cutoff_pf_reads_label, initial[cutoff_pf_reads])])
                             ),
+                            core.Graph(id=ids['unmapped-reads'],
+                                figure=generate_unmapped_reads(df, initial)
+                            ),
+                            core.Graph(id=ids['non-primary-reads'],
+                                figure=generate_nonprimary_reads(df, initial)
+                            ),
+                            core.Graph(id=ids['on-target-reads'],
+                                figure=generate_on_target_reads(df,initial)
+                            ),
+                            core.Graph(id=ids['mean-insert-size'],
+                                figure=generate_mean_insert_size(df, initial)
+                            )
                         ]),
                         # Tables tab
                         core.Tab(label="Tables",

--- a/application/dash_application/views/single_lane_wgs.py
+++ b/application/dash_application/views/single_lane_wgs.py
@@ -397,61 +397,74 @@ def layout(query_string):
                     ids["insert-mean-cutoff"], initial[cutoff_insert_mean]),
             ]),
 
-            html.Div(className="seven columns", children=[
-                core.Graph(
-                    id=ids["total-reads"],
-                    figure=generate_total_reads(
-                        df,
-                        PINERY_COL.SampleName,
-                        special_cols["Total Reads (Passed Filter)"],
-                        initial["colour_by"], initial["shape_by"],
-                        initial["shownames_val"],
-                        [(cutoff_pf_reads_label, initial[cutoff_pf_reads])])
-                ),
-                core.Graph(
-                    id=ids["mean-insert"],
-                    figure=generate_mean_insert_size(df, initial)
-                ),
-                core.Graph(
-                    id=ids["duplication"],
-                    figure=generate_duplication(df, initial)
-                ),
-                core.Graph(
-                    id=ids["purity"],
-                    figure=generate_purity(df, initial)
-                ),
-                core.Graph(
-                    id=ids["ploidy"],
-                    figure=generate_ploidy(df, initial)
-                ),
-                core.Graph(
-                    id=ids["unmapped-reads"],
-                    figure=generate_unmapped_reads(df, initial)
-                ),
-                core.Graph(
-                    id=ids["non-primary-reads"],
-                    figure=generate_non_primary(df, initial)
-                ),
-                core.Graph(
-                    id=ids["on-target-reads"],
-                    figure=generate_on_target_reads(df, initial)
-                ),
-            ]),
-        ]),
-        table_tabs(
-            ids["failed-samples"],
-            ids["data-table"],
-            df,
-            wgs_table_columns,
-            [
-                (cutoff_insert_mean_label, BAMQC_COL.InsertMean, initial[cutoff_insert_mean],
-                 (lambda row, col, cutoff: row[col] < cutoff)),
-                (cutoff_pf_reads_label,
-                 special_cols["Total Reads (Passed Filter)"], initial[cutoff_pf_reads],
-                 (lambda row, col, cutoff: row[col] < cutoff)),
-            ])
-    ]),
-])
+            	# Graphs + Tables tabs
+                html.Div(className="seven columns", 
+                children=[
+                    core.Tabs([
+                        # Graphs tab
+                        core.Tab(label="Graphs",
+                        children=[
+                            core.Graph(
+                                id=ids["total-reads"],
+                                figure=generate_total_reads(
+                                    df,
+                                    PINERY_COL.SampleName,
+                                    special_cols["Total Reads (Passed Filter)"],
+                                    initial["colour_by"], initial["shape_by"],
+                                    initial["shownames_val"],
+                                    [(cutoff_pf_reads_label, initial[cutoff_pf_reads])])
+                            ),
+                            core.Graph(
+                                id=ids["mean-insert"],
+                                figure=generate_mean_insert_size(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["duplication"],
+                                figure=generate_duplication(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["purity"],
+                                figure=generate_purity(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["ploidy"],
+                                figure=generate_ploidy(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["unmapped-reads"],
+                                figure=generate_unmapped_reads(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["non-primary-reads"],
+                                figure=generate_non_primary(df, initial)
+                            ),
+                            core.Graph(
+                                id=ids["on-target-reads"],
+                                figure=generate_on_target_reads(df, initial)
+                            )
+                        ]),
+                        # Tables tab
+                        core.Tab(label="Tables",
+                        children=[
+                            table_tabs(
+                                ids["failed-samples"],
+                                ids["data-table"],
+                                df,
+                                wgs_table_columns,
+                                [
+                                    (cutoff_insert_mean_label, BAMQC_COL.InsertMean, initial[cutoff_insert_mean],
+                                    (lambda row, col, cutoff: row[col] < cutoff)),
+                                    (cutoff_pf_reads_label,
+                                    special_cols["Total Reads (Passed Filter)"], initial[cutoff_pf_reads],
+                                    (lambda row, col, cutoff: row[col] < cutoff)),
+                                ]
+                            )                    
+                        ])
+                    ]) # End Tabs
+                ]) # End Div
+            ]) # End Div
+        ]) # End Div
+    ]) # End Loading
 
 
 def init_callbacks(dash_app):


### PR DESCRIPTION
Helps make the tables more obvious, part of getting Dashi to be accepted as a replacement for the Run Reports. 

Minor display issue where data tables have margin-left of -15px which causes them to be wider than the tabs and have no whitespace against the sidebar.