### PR TITLE
[GR-1091] Single lane targeted sequencing uses bamqc3

### DIFF
--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -9,7 +9,7 @@ from ..utility.table_builder import table_tabs, cutoff_table_data_ius
 from ..utility import df_manipulation as util
 from ..utility import sidebar_utils
 from ..utility import log_utils
-from gsiqcetl.column import BamQcColumn
+from gsiqcetl.column import BamQc3Column
 import pinery
 import logging
 
@@ -59,7 +59,7 @@ ids = init_ids([
     'data-table'
 ])
 
-BAMQC_COL = BamQcColumn
+BAMQC_COL = BamQc3Column
 PINERY_COL = pinery.column.SampleProvenanceColumn
 INSTRUMENT_COLS = pinery.column.InstrumentWithModelColumn
 RUN_COLS = pinery.column.RunsColumn
@@ -81,7 +81,7 @@ cutoff_insert_mean = "cutoff_insert_mean"
 initial[cutoff_insert_mean] = 150
 
 def get_bamqc_data():
-    bamqc_df = util.get_bamqc()
+    bamqc_df = util.get_bamqc3()
     bamqc_df[special_cols["Total Reads (Passed Filter)"]] = round(
         bamqc_df[BAMQC_COL.TotalReads] / 1e6, 3)
 
@@ -123,7 +123,6 @@ first_col_set = [
     PINERY_COL.SampleName, PINERY_COL.StudyTitle,
 ]
 most_bamqc_cols = [*BAMQC_COL.values()]
-most_bamqc_cols.remove(BAMQC_COL.BamFile)
 later_col_set = [
     PINERY_COL.PrepKit, PINERY_COL.TissuePreparation,
     PINERY_COL.LibrarySourceTemplateType, PINERY_COL.ExternalName,


### PR DESCRIPTION
I compared data between bamqc and bamqc3 that is displayed in dashi. One is normal scale, the other is log scale to show differences near the low values (MiSeq all clump together).

Normal scales:
![plot](https://user-images.githubusercontent.com/37381890/77081650-5302df80-69d1-11ea-940a-a7f28b67dd1d.png)

Log scales:
![plot_log](https://user-images.githubusercontent.com/37381890/77081666-58602a00-69d1-11ea-8cbb-65a382289460.png)

* Unmapped Reads: Looks good. Log scale shows a couple of outliers in the MiSeq level.
* Non-Primary Reads: bamqc has higher numbers than bamqc3. No idea why, as non-primary reads is fairly straightforward to count. bamqc3 uses `samtools stats`, which I trust more than the homebrew solution in bamqc
* Insert Mean: Different. Again bamqc3 uses `samtools stats`.
* Total Reads: bamqc is consistently higher than bamqc3. Best guess is that bamqc includes non-primary reads. I trust bamqc3, as I have verified it against `samtools flagstat`
* Reads on Target: Looks fairly good, with some MiSeq outlier groups.
