### PR TITLE
[GR-1130] lock down dependencies to known working versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
 ## Changed
+  * locks down dependency versions to specific versions to avoid breaking changes, please run 'pip install -r requirements.txt --upgrade --no-cache-dir` 
+
+## [200422-1118] - 2020-04-22
+## Changed
   * SARS-CoV-2 coverage graph uses median coverage with 10/90 percentile error bars
   * No legends for cutoff lines nor highlighted samples, to preserve graph widths
   * SARS-CoV-2 On Target bar chart no longer shows unmapped numbers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 Flask_Caching>=1.7.2
-dash_html_components>=1.0.1
-dash_bootstrap_components>=0.7.2
+dash_html_components==1.0.3
+dash_bootstrap_components==0.7.2
 pandas>=1.0.1
 Flask>=1.1.1
-dash_core_components>=1.3.1
-dash>=1.4.1
+dash_core_components==1.9.1
+dash==1.11.0
 prometheus_flask_exporter>=0.11.0
 plotly>=4.2.1
 git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v0.27.0
@@ -13,3 +13,4 @@ scipy>=1.2.0
 python-dotenv>=0.10.3
 gevent>=1.4.0
 gunicorn>=20.0.4
+dash_renderer==1.3.0


### PR DESCRIPTION
dash-renderer 1.4.0 in particular seems to cause hanging in-browser (including but not limited to crashing the whole tab) when layouts don't meet its new standards