### PR TITLE
[GR-1146] Select Project by URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
+## Changed
 
+## Added
+  * Projects may now be specified through the url for all reports. Add 'project=' to the query portion of the URL.
 ## [200511-1447] - 2020-05-11
 ## Changed
   * Style changes to bar plots

--- a/application/__init__.py
+++ b/application/__init__.py
@@ -1,9 +1,14 @@
 from flask import Flask
 from flask_caching import Cache
 from prometheus_flask_exporter import PrometheusMetrics
+import pandas
 
 ## Set up Flask application, attach extensions, and load configuration
 def create_app(debug=False):
+    # pandas debug options
+    pandas.set_option('display.max_rows', None)
+    pandas.set_option('display.max_columns', None)
+
     # Construct new Flask core
     app = Flask(__name__,
             instance_relative_config=False)

--- a/application/dash_application/utility/sidebar_utils.py
+++ b/application/dash_application/utility/sidebar_utils.py
@@ -106,9 +106,10 @@ def select_instruments(all_instruments_id: str, instruments_id: str,
 
 
 def select_projects(all_projects_id: str, projects_id: str, projects: List[
-        str]) -> core.Loading:
+        str], requested_projects) -> core.Loading:
     return select_with_select_all("All Projects", all_projects_id,
-                                  "Filter by Projects", projects_id, projects)
+                                  "Filter by Projects", projects_id, projects,
+                                  requested_projects)
 
 
 def select_reference(all_references_id: str, references_id: str, references: List[

--- a/application/dash_application/utility/sidebar_utils.py
+++ b/application/dash_application/utility/sidebar_utils.py
@@ -318,12 +318,15 @@ def parse_query(query) -> List[str]:
     queries = {
         "req_start": None,
         "req_end": None,
-        "req_runs": []
+        "req_runs": [],
+        "req_projects": []
     }
     if "last" in query_dict:
         queries["req_start"], queries["req_end"] = get_requested_run_date_range(query_dict["last"][0])
     if "run" in query_dict:
         queries["req_runs"] = query_dict["run"]
+    if "project" in query_dict:
+        queries["req_projects"] = query_dict["project"]
     return queries
 
 

--- a/application/dash_application/utility/table_builder.py
+++ b/application/dash_application/utility/table_builder.py
@@ -4,9 +4,14 @@ import dash_core_components as core
 import dash_html_components as html
 import dash_table as tabl
 import numpy
+import pandas
 from pandas import DataFrame
 import pinery
+from enum import Enum
 
+class Mode(Enum):
+    IUS = 0
+    MERGED = 1
 
 def build_table(table_id: str, columns: List[str], df: DataFrame):
     return tabl.DataTable(
@@ -93,8 +98,11 @@ def printable_cutoff(cutoff: float) -> str:
 
 def cutoff_table(table_id: str, data: DataFrame, limits: List[Tuple[str, str,
                                                                     float,
-                                                                    bool]]):
-    (failure_df, columns) = cutoff_table_data_ius(data, limits)
+                                                                    bool]], mode):
+    if mode == Mode.IUS:
+        (failure_df, columns) = cutoff_table_data_ius(data, limits)
+    elif mode == Mode.MERGED:
+        (failure_df, columns) = cutoff_table_data_merged(data, limits)
     return tabl.DataTable(
         id=table_id,
         columns=columns,
@@ -124,8 +132,8 @@ def cutoff_table(table_id: str, data: DataFrame, limits: List[Tuple[str, str,
     )
 
 
-def table_tabs(failed_id: str, data_id: str, empty_data: DataFrame, table_columns: List[str],
-               limits: List[Tuple[str, str, float, bool]]):
+def _table_tabs(failed_id: str, data_id: str, empty_data: DataFrame, table_columns: List[str],
+               limits: List[Tuple[str, str, float, bool]], mode):
     return core.Tabs(
         [
             core.Tab(
@@ -137,7 +145,8 @@ def table_tabs(failed_id: str, data_id: str, empty_data: DataFrame, table_column
                             cutoff_table(
                                 failed_id,
                                 empty_data,
-                                limits)]),
+                                limits,
+                                mode)]),
                 ]),
             core.Tab(
                 label="🐌 Raw Data 🐌",
@@ -150,3 +159,11 @@ def table_tabs(failed_id: str, data_id: str, empty_data: DataFrame, table_column
                                 table_columns,
                                 empty_data)]),
                 ])])
+
+def table_tabs_single_lane(failed_id: str, data_id: str, empty_data: DataFrame, table_columns: List[str],
+               limits: List[Tuple[str, str, float, bool]]):
+    return _table_tabs(failed_id, data_id, empty_data, table_columns, limits, Mode.IUS)
+
+def table_tabs_call_ready(failed_id: str, data_id: str, empty_data: DataFrame, table_columns: List[str],
+               limits: List[Tuple[str, str, float, bool]]):
+    return _table_tabs(failed_id, data_id, empty_data, table_columns, limits, Mode.MERGED)

--- a/application/dash_application/utility/table_builder.py
+++ b/application/dash_application/utility/table_builder.py
@@ -8,6 +8,9 @@ import pandas
 from pandas import DataFrame
 import pinery
 from enum import Enum
+import logging
+
+logger = logging.getLogger(__name__)
 
 class Mode(Enum):
     IUS = 0
@@ -103,6 +106,9 @@ def cutoff_table(table_id: str, data: DataFrame, limits: List[Tuple[str, str,
         (failure_df, columns) = cutoff_table_data_ius(data, limits)
     elif mode == Mode.MERGED:
         (failure_df, columns) = cutoff_table_data_merged(data, limits)
+    else:
+        logger.error("Unrecognized Mode in cutoff_table: {0}".format(mode))
+        raise NotImplementedError
     return tabl.DataTable(
         id=table_id,
         columns=columns,

--- a/application/dash_application/views/SARS-CoV-2.py
+++ b/application/dash_application/views/SARS-CoV-2.py
@@ -257,6 +257,8 @@ def layout(query_string):
     elif "req_start" in query and query["req_start"]:
         initial["runs"] = ALL_RUNS
         query["req_runs"] = ALL_RUNS  # fill in the runs dropdown
+    if "req_projects" in query and query["req_projects"]:
+        initial["projects"] = query["req_projects"]
 
     df = reshape_single_lane_df(BEDTOOLS_DF, initial["runs"], initial["instruments"],
                                 initial["projects"], None, initial["kits"],
@@ -300,7 +302,8 @@ def layout(query_string):
 
                     sidebar_utils.select_projects(ids["all-projects"],
                                                 ids["projects-list"],
-                                                ALL_PROJECTS),
+                                                ALL_PROJECTS,
+                                                query["req_projects"]),
 
                     sidebar_utils.select_kits(ids["all-kits"], ids["kits-list"],
                                             ALL_KITS),

--- a/application/dash_application/views/SARS-CoV-2.py
+++ b/application/dash_application/views/SARS-CoV-2.py
@@ -5,7 +5,7 @@ import dash_core_components as core
 from dash.dependencies import Input, Output, State
 from ..dash_id import init_ids
 from ..utility.plot_builder import *
-from ..utility.table_builder import table_tabs, cutoff_table_data_ius
+from ..utility.table_builder import table_tabs_single_lane, cutoff_table_data_ius
 from ..utility import df_manipulation as util
 from ..utility import sidebar_utils
 from ..utility import log_utils
@@ -397,7 +397,7 @@ def layout(query_string):
                         # Tables tab
                         core.Tab(label="Tables",
                         children=[
-                            table_tabs(
+                            table_tabs_single_lane(
                                 ids["failed-samples"],
                                 ids["data-table"],
                                 df,

--- a/application/dash_application/views/call_ready_rna.py
+++ b/application/dash_application/views/call_ready_rna.py
@@ -186,6 +186,11 @@ def generate_rrna_contam(df, graph_params):
 
 def layout(query_string):
     query = sidebar_utils.parse_query(query_string)
+    if "req_projects" in query and query["req_projects"]:
+        initial["projects"] = query["req_projects"]
+    elif "req_start" in query and query["req_start"]:
+        initial["projects"] = ALL_PROJECTS
+        query["req_projects"] = ALL_PROJECTS  # fill in the projects dropdown
 
     df = reshape_call_ready_df(RNA_DF, initial["projects"], initial["references"],
                                initial["tissue_materials"], initial["sample_types"],
@@ -209,7 +214,8 @@ def layout(query_string):
                     # Filters
                     sidebar_utils.select_projects(ids["all-projects"],
                                                   ids["projects-list"],
-                                                  ALL_PROJECTS),
+                                                  ALL_PROJECTS,
+                                                  query["req_projects"]),
                     sidebar_utils.select_reference(ids["all-references"],
                                                    ids["references-list"],
                                                    ALL_REFERENCES),

--- a/application/dash_application/views/call_ready_rna.py
+++ b/application/dash_application/views/call_ready_rna.py
@@ -7,7 +7,7 @@ from dash.dependencies import Input, Output, State
 
 from ..dash_id import init_ids
 from ..utility.plot_builder import *
-from ..utility.table_builder import table_tabs, cutoff_table_data_merged
+from ..utility.table_builder import table_tabs_call_ready, cutoff_table_data_merged
 from ..utility import df_manipulation as util
 from ..utility import sidebar_utils
 from ..utility import log_utils
@@ -305,7 +305,7 @@ def layout(query_string):
                         # Tables tab
                         core.Tab(label="Tables",
                         children=[
-                            table_tabs(
+                            table_tabs_call_ready(
                                 ids["failed-samples"],
                                 ids["data-table"],
                                 df,

--- a/application/dash_application/views/call_ready_ts_1.py
+++ b/application/dash_application/views/call_ready_ts_1.py
@@ -313,6 +313,11 @@ def generate_gc_dropout(df, graph_params):
 
 def layout(query_string):
     query = sidebar_utils.parse_query(query_string)
+    if "req_projects" in query and query["req_projects"]:
+        initial["projects"] = query["req_projects"]
+    elif "req_start" in query and query["req_start"]:
+        initial["projects"] = ALL_PROJECTS
+        query["req_projects"] = ALL_PROJECTS  # fill in the projects dropdown
 
     df = reshape_call_ready_df(TS_DF, initial["projects"], initial["references"],
                                initial["tissue_materials"], initial["sample_types"],
@@ -338,7 +343,8 @@ def layout(query_string):
                     # Filters
                     sidebar_utils.select_projects(ids["all-projects"],
                                                   ids["projects-list"],
-                                                  ALL_PROJECTS),
+                                                  ALL_PROJECTS,
+                                                  query["req_projects"]),
                     sidebar_utils.select_reference(ids["all-references"],
                                                    ids["references-list"],
                                                    ALL_REFERENCES),

--- a/application/dash_application/views/call_ready_ts_1.py
+++ b/application/dash_application/views/call_ready_ts_1.py
@@ -8,7 +8,7 @@ from dash.dependencies import Input, Output, State
 import gsiqcetl.column
 from ..dash_id import init_ids
 from ..utility.plot_builder import *
-from ..utility.table_builder import table_tabs, cutoff_table_data_merged
+from ..utility.table_builder import table_tabs_call_ready, cutoff_table_data_merged
 from ..utility import df_manipulation as util
 from ..utility import sidebar_utils
 from ..utility import log_utils
@@ -470,7 +470,7 @@ def layout(query_string):
                         # Tables tab
                         core.Tab(label="Tables",
                         children=[
-                            table_tabs(
+                            table_tabs_call_ready(
                                 ids["failed-samples"],
                                 ids["data-table"],
                                 df,

--- a/application/dash_application/views/call_ready_ts_2.py
+++ b/application/dash_application/views/call_ready_ts_2.py
@@ -339,6 +339,11 @@ def generate_bait(df):
 
 def layout(query_string):
     query = sidebar_utils.parse_query(query_string)
+    if "req_projects" in query and query["req_projects"]:
+        initial["projects"] = query["req_projects"]
+    elif "req_start" in query and query["req_start"]:
+        initial["projects"] = ALL_PROJECTS
+        query["req_projects"] = ALL_PROJECTS  # fill in the projects dropdown
 
     df = reshape_call_ready_df(TS_DF, initial["projects"],
                                initial["references"],
@@ -367,7 +372,8 @@ def layout(query_string):
                     # Filters
                     sidebar_utils.select_projects(ids["all-projects"],
                                                   ids["projects-list"],
-                                                  ALL_PROJECTS),
+                                                  ALL_PROJECTS,
+                                                  query["req_projects"]),
                     sidebar_utils.select_reference(ids["all-references"],
                                                    ids["references-list"],
                                                    ALL_REFERENCES),

--- a/application/dash_application/views/call_ready_ts_2.py
+++ b/application/dash_application/views/call_ready_ts_2.py
@@ -8,7 +8,7 @@ from dash.dependencies import Input, Output, State
 import gsiqcetl.column
 from ..dash_id import init_ids
 from ..utility.plot_builder import *
-from ..utility.table_builder import table_tabs, cutoff_table_data_merged
+from ..utility.table_builder import table_tabs_call_ready, cutoff_table_data_merged
 from ..utility import df_manipulation as util
 from ..utility import sidebar_utils
 from ..utility import log_utils
@@ -514,7 +514,7 @@ def layout(query_string):
                         # Tables tab
                         core.Tab(label="Tables",
                         children=[
-                            table_tabs(
+                            table_tabs_call_ready(
                                 ids["failed-samples"],
                                 ids["data-table"],
                                 df,

--- a/application/dash_application/views/call_ready_wgs.py
+++ b/application/dash_application/views/call_ready_wgs.py
@@ -276,7 +276,11 @@ def generate_unmapped_reads(df, graph_params):
 def layout(query_string):
     query = sidebar_utils.parse_query(query_string)
     # no queries apply here...yet
-
+    if "req_projects" in query and query["req_projects"]:
+        initial["projects"] = query["req_projects"]
+    elif "req_start" in query and query["req_start"]:
+        initial["runs"] = ALL_PROJECTS
+        query["req_runs"] = ALL_PROJECTS  # fill in the projects dropdown
     df = reshape_call_ready_df(WGS_DF, initial["projects"], initial["references"],
                                initial["tissue_materials"],
                                initial["sample_types"],

--- a/application/dash_application/views/call_ready_wgs.py
+++ b/application/dash_application/views/call_ready_wgs.py
@@ -9,7 +9,7 @@ import gsiqcetl.column
 from ..dash_id import init_ids
 
 from ..utility.plot_builder import *
-from ..utility.table_builder import table_tabs, cutoff_table_data_merged
+from ..utility.table_builder import table_tabs_call_ready, cutoff_table_data_merged
 from ..utility import df_manipulation as util
 from ..utility import sidebar_utils, log_utils
 
@@ -469,7 +469,7 @@ def layout(query_string):
                                  # Tables tab
                                  core.Tab(label="Tables",
                                           children=[
-                                              table_tabs(
+                                              table_tabs_call_ready(
                                                   ids["failed-samples"],
                                                   ids["data-table"],
                                                   df,

--- a/application/dash_application/views/call_ready_wgs.py
+++ b/application/dash_application/views/call_ready_wgs.py
@@ -275,12 +275,11 @@ def generate_unmapped_reads(df, graph_params):
 
 def layout(query_string):
     query = sidebar_utils.parse_query(query_string)
-    # no queries apply here...yet
     if "req_projects" in query and query["req_projects"]:
         initial["projects"] = query["req_projects"]
     elif "req_start" in query and query["req_start"]:
-        initial["runs"] = ALL_PROJECTS
-        query["req_runs"] = ALL_PROJECTS  # fill in the projects dropdown
+        initial["projects"] = ALL_PROJECTS
+        query["req_projects"] = ALL_PROJECTS  # fill in the projects dropdown
     df = reshape_call_ready_df(WGS_DF, initial["projects"], initial["references"],
                                initial["tissue_materials"],
                                initial["sample_types"],
@@ -306,7 +305,8 @@ def layout(query_string):
                     # Filters
                     sidebar_utils.select_projects(ids["all-projects"],
                                                   ids["projects-list"],
-                                                  ALL_PROJECTS),
+                                                  ALL_PROJECTS, 
+                                                  query["req_projects"]),
                     sidebar_utils.select_reference(ids["all-references"],
                                                    ids["references-list"],
                                                    ALL_REFERENCES),

--- a/application/dash_application/views/single_lane_cfmedip.py
+++ b/application/dash_application/views/single_lane_cfmedip.py
@@ -5,7 +5,7 @@ import dash_core_components as core
 from dash.dependencies import Input, Output, State
 from ..dash_id import init_ids
 from ..utility.plot_builder import *
-from ..utility.table_builder import table_tabs, cutoff_table_data_ius
+from ..utility.table_builder import table_tabs_single_lane, cutoff_table_data_ius
 from ..utility import df_manipulation as util
 from ..utility import sidebar_utils
 from ..utility import log_utils
@@ -416,7 +416,7 @@ def layout(query_string):
                         # Tables tab
                         core.Tab(label="Tables",
                         children=[
-                            table_tabs(
+                            table_tabs_single_lane(
                                 ids["failed-samples"],
                                 ids["data-table"],
                                 df,

--- a/application/dash_application/views/single_lane_cfmedip.py
+++ b/application/dash_application/views/single_lane_cfmedip.py
@@ -267,6 +267,8 @@ def layout(query_string):
     elif "req_start" in query and query["req_start"]:
         initial["runs"] = ALL_RUNS
         query["req_runs"] = ALL_RUNS  # fill in the runs dropdown
+    if "req_projects" in query and query["req_projects"]:
+        initial["projects"] = query["req_projects"]
 
     df = reshape_cfmedip_df(cfmedip, initial["runs"], initial["instruments"],
                                 initial["projects"], initial["references"], initial["kits"],
@@ -305,7 +307,8 @@ def layout(query_string):
 
                     sidebar_utils.select_projects(ids["all-projects"],
                                                 ids["projects-list"],
-                                                ALL_PROJECTS),
+                                                ALL_PROJECTS,
+                                                query["req_projects"]),
 
                     sidebar_utils.select_reference(ids["all-references"],
                                                    ids["references-list"],

--- a/application/dash_application/views/single_lane_rna.py
+++ b/application/dash_application/views/single_lane_rna.py
@@ -6,7 +6,7 @@ from dash.dependencies import Input, Output, State
 
 from ..dash_id import init_ids
 from ..utility.plot_builder import *
-from ..utility.table_builder import table_tabs, cutoff_table_data_ius
+from ..utility.table_builder import table_tabs_single_lane, cutoff_table_data_ius
 from ..utility import df_manipulation as util
 from ..utility import sidebar_utils
 from ..utility import log_utils
@@ -469,7 +469,7 @@ def layout(query_string):
                         # Tables tab
                         core.Tab(label="Tables",
                         children=[
-                            table_tabs(
+                            table_tabs_single_lane(
                                 ids["failed-samples"],
                                 ids["data-table"],
                                 df,

--- a/application/dash_application/views/single_lane_rna.py
+++ b/application/dash_application/views/single_lane_rna.py
@@ -304,6 +304,8 @@ def layout(query_string):
     elif "req_start" in query and query["req_start"]:
         initial["runs"] = ALL_RUNS
         query["req_runs"] = ALL_RUNS  # fill in the runs dropdown
+    if "req_projects" in query and query["req_projects"]:
+        initial["projects"] = query["req_projects"]
 
     df = reshape_single_lane_df(RNA_DF, initial["runs"], initial["instruments"],
                                 initial["projects"], initial["references"], initial["kits"],
@@ -342,7 +344,8 @@ def layout(query_string):
 
                 sidebar_utils.select_projects(ids["all-projects"],
                                               ids["projects-list"],
-                                              ALL_PROJECTS),
+                                              ALL_PROJECTS,
+                                              query["req_projects"]),
 
                 sidebar_utils.select_reference(ids["all-references"],
                                               ids["references-list"],

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -205,7 +205,7 @@ def dataversion():
 
 def layout(query_string):
     query = sidebar_utils.parse_query(query_string)
-    # intial runs: should be empty unless query requests otherwise:
+    # initial runs: should be empty unless query requests otherwise:
     #  * if query.req_run: use query.req_run
     #  * if query.req_start/req_end: use all runs, so that the start/end filters will be applied
     if "req_runs" in query and query["req_runs"]:

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -5,7 +5,7 @@ import dash_core_components as core
 from dash.dependencies import Input, Output, State
 from ..dash_id import init_ids
 from ..utility.plot_builder import *
-from ..utility.table_builder import table_tabs, cutoff_table_data_ius
+from ..utility.table_builder import table_tabs_single_lane, cutoff_table_data_ius
 from ..utility import df_manipulation as util
 from ..utility import sidebar_utils
 from ..utility import log_utils
@@ -353,7 +353,7 @@ def layout(query_string):
                         # Tables tab
                         core.Tab(label="Tables",
                         children=[
-                            table_tabs(
+                            table_tabs_single_lane(
                                 ids["failed-samples"],
                                 ids["data-table"],
                                 df,

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -213,6 +213,8 @@ def layout(query_string):
     elif "req_start" in query and query["req_start"]:
         initial["runs"] = ALL_RUNS
         query["req_runs"] = ALL_RUNS  # fill in the runs dropdown
+    if "req_projects" in query and query["req_projects"]:
+        initial["projects"] = query["req_projects"]
 
     df = reshape_single_lane_df(bamqc, initial["runs"], initial["instruments"],
                                 initial["projects"], initial["references"], initial["kits"],
@@ -251,7 +253,8 @@ def layout(query_string):
 
                     sidebar_utils.select_projects(ids["all-projects"],
                                                 ids["projects-list"],
-                                                ALL_PROJECTS),
+                                                ALL_PROJECTS,
+                                                query["req_projects"]),
 
                     sidebar_utils.select_reference(ids["all-references"],
                                                    ids["references-list"],

--- a/application/dash_application/views/single_lane_wgs.py
+++ b/application/dash_application/views/single_lane_wgs.py
@@ -9,7 +9,7 @@ import gsiqcetl.column
 import pinery
 from ..dash_id import init_ids
 from ..utility.plot_builder import *
-from ..utility.table_builder import table_tabs, cutoff_table_data_ius
+from ..utility.table_builder import table_tabs_single_lane, cutoff_table_data_ius
 from ..utility import df_manipulation as util
 from ..utility import sidebar_utils
 from ..utility import log_utils
@@ -435,7 +435,7 @@ def layout(query_string):
                         # Tables tab
                         core.Tab(label="Tables",
                         children=[
-                            table_tabs(
+                            table_tabs_single_lane(
                                 ids["failed-samples"],
                                 ids["data-table"],
                                 df,

--- a/application/dash_application/views/single_lane_wgs.py
+++ b/application/dash_application/views/single_lane_wgs.py
@@ -282,6 +282,8 @@ def layout(query_string):
     elif "req_start" in query and query["req_start"]:
         initial["runs"] = ALL_RUNS
         query["req_runs"] = ALL_RUNS  # fill in the runs dropdown
+    if "req_projects" in query and query["req_projects"]:
+        initial["projects"] = query["req_projects"]
 
     df = reshape_single_lane_df(WGS_DF, initial["runs"], initial["instruments"],
                                 initial["projects"], initial["references"], initial["kits"],
@@ -321,7 +323,8 @@ def layout(query_string):
 
                 sidebar_utils.select_projects(ids["all-projects"],
                                               ids["projects-list"],
-                                              ALL_PROJECTS),
+                                              ALL_PROJECTS,
+                                              query["req_projects"]),
 
                 sidebar_utils.select_reference(ids["all-references"],
                                                ids["references-list"],


### PR DESCRIPTION
Adds a 'project' URL parameter to every report.
Call-Ready pages can use 'project', Single-Lane pages can use a combination of 'run' and 'project' to pre-fill the sidebar if that's really something you want.
Required some refactoring of table_tabs due to crashes trying to shove call-ready data into IUS columns