### PR TITLE
[GR-1181] Single-Lane Date Sort

### DIFF
--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -383,6 +383,8 @@ def get_pinery_merged_samples(active_projects_only=True):
 def get_runs():
     return _runs_with_instruments.copy(deep=True)
 
+def df_with_runs(df):
+    return pandas.merge(df, get_runs(), left_on=PINERY_COL.SequencerRunName, right_on='name')
 
 def df_with_pinery_samples_ius(df: DataFrame, pinery_samples: DataFrame, ius_cols:
                            List[str]):

--- a/application/dash_application/utility/plot_builder.py
+++ b/application/dash_application/utility/plot_builder.py
@@ -10,6 +10,7 @@ import gsiqcetl.column
 from .df_manipulation import sample_type_col
 from .sidebar_utils import runs_in_range
 import re
+import pdb
 
 PINERY_COL = pinery.column.SampleProvenanceColumn
 COMMON_COL = gsiqcetl.column.ColumnNames

--- a/application/dash_application/utility/plot_builder.py
+++ b/application/dash_application/utility/plot_builder.py
@@ -634,7 +634,6 @@ def get_initial_single_lane_values():
         "library_designs": [],
         "start_date": None,
         "end_date": None,
-        "completion_date": None,
         "first_sort": pinery.column.SampleProvenanceColumn.StudyTitle,
         "second_sort": None,
         "colour_by": pinery.column.SampleProvenanceColumn.StudyTitle,

--- a/application/dash_application/utility/plot_builder.py
+++ b/application/dash_application/utility/plot_builder.py
@@ -211,6 +211,8 @@ def reshape_single_lane_df(df, runs, instruments, projects, references, kits, li
             library_designs)]
     df = df[df[pinery.column.SampleProvenanceColumn.SequencerRunName].isin(runs_in_range(start_date, end_date))]
     sort_by = [first_sort, second_sort]
+    if first_sort == "start_date":
+        pdb.set_trace()
     df = df.sort_values(by=sort_by)
     df = fill_in_shape_col(df, shape_by, shape_or_colour_values)
     df = fill_in_colour_col(df, colour_by, shape_or_colour_values, searchsample)
@@ -632,6 +634,7 @@ def get_initial_single_lane_values():
         "library_designs": [],
         "start_date": None,
         "end_date": None,
+        "completion_date": None,
         "first_sort": pinery.column.SampleProvenanceColumn.StudyTitle,
         "second_sort": None,
         "colour_by": pinery.column.SampleProvenanceColumn.StudyTitle,

--- a/application/dash_application/utility/plot_builder.py
+++ b/application/dash_application/utility/plot_builder.py
@@ -211,8 +211,6 @@ def reshape_single_lane_df(df, runs, instruments, projects, references, kits, li
             library_designs)]
     df = df[df[pinery.column.SampleProvenanceColumn.SequencerRunName].isin(runs_in_range(start_date, end_date))]
     sort_by = [first_sort, second_sort]
-    if first_sort == "start_date":
-        pdb.set_trace()
     df = df.sort_values(by=sort_by)
     df = fill_in_shape_col(df, shape_by, shape_or_colour_values)
     df = fill_in_colour_col(df, colour_by, shape_or_colour_values, searchsample)

--- a/application/dash_application/utility/sidebar_utils.py
+++ b/application/dash_application/utility/sidebar_utils.py
@@ -279,6 +279,8 @@ def show_data_labels_input_single_lane(
             {'label': 'Tissue Origin', 'value': PINERY_COL.TissueOrigin},
             {'label': 'Tissue Preparation', 'value': PINERY_COL.TissuePreparation},
             {'label': 'Tissue Type', 'value': PINERY_COL.TissueType},
+            {'label': 'Run start date', 'value': 'start_date'},
+            {'label': 'Run end date', 'value': 'end_date'}
         ])
 
 

--- a/application/dash_application/utility/sidebar_utils.py
+++ b/application/dash_application/utility/sidebar_utils.py
@@ -280,7 +280,7 @@ def show_data_labels_input_single_lane(
             {'label': 'Tissue Preparation', 'value': PINERY_COL.TissuePreparation},
             {'label': 'Tissue Type', 'value': PINERY_COL.TissueType},
             {'label': 'Run start date', 'value': 'start_date'},
-            {'label': 'Run end date', 'value': 'end_date'}
+            {'label': 'Run end date', 'value': 'completion_date'}
         ])
 
 

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -12,6 +12,7 @@ from ..utility import log_utils
 from gsiqcetl.column import BamQc3Column
 import pinery
 import logging
+import pdb
 
 logger = logging.getLogger(__name__)
 
@@ -158,6 +159,7 @@ shape_colour = ColourShapeSingleLane(
 )
 # Add shape, colour, and size cols to dataframe 
 bamqc = add_graphable_cols(bamqc, initial, shape_colour.items_for_df())
+bamqc = util.df_with_runs(bamqc)
 
 SORT_BY = sidebar_utils.default_first_sort + [
     {"label": "Total Reads",
@@ -308,13 +310,23 @@ def layout(query_string):
                     sidebar_utils.select_first_sort(
                         ids['first-sort'],
                         initial["first_sort"],
-                        SORT_BY,
+                        SORT_BY + 
+                            [{"label": "Run start date",
+                            "value": "start_date"},
+                            {"label": "Run end date",
+                            "value": "end_date"}],
                     ),
 
                     sidebar_utils.select_second_sort(
                         ids['second-sort'],
                         initial["second_sort"],
-                        SORT_BY,
+                        SORT_BY +
+                        [
+                                {"label": "Run start date",
+                                "value": "start_date"},
+                                {"label": "Run end date",
+                                "value": "end_date"}
+                        ]
                     ),
 
                     sidebar_utils.select_colour_by(ids['colour-by'],

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -159,6 +159,7 @@ shape_colour = ColourShapeSingleLane(
 )
 # Add shape, colour, and size cols to dataframe 
 bamqc = add_graphable_cols(bamqc, initial, shape_colour.items_for_df())
+#pdb.set_trace()
 bamqc = util.df_with_runs(bamqc)
 
 SORT_BY = sidebar_utils.default_first_sort + [
@@ -252,7 +253,7 @@ def layout(query_string):
     df = reshape_single_lane_df(bamqc, initial["runs"], initial["instruments"],
                                 initial["projects"], initial["references"], initial["kits"],
                                 initial["library_designs"], initial["start_date"],
-                                initial["end_date"], initial["first_sort"],
+                                initial["completion_date"], initial["first_sort"],
                                 initial["second_sort"], initial["colour_by"],
                                 initial["shape_by"], shape_colour.items_for_df(), [])
 
@@ -314,7 +315,7 @@ def layout(query_string):
                             [{"label": "Run start date",
                             "value": "start_date"},
                             {"label": "Run end date",
-                            "value": "end_date"}],
+                            "value": "completion_date"}],
                     ),
 
                     sidebar_utils.select_second_sort(
@@ -325,7 +326,7 @@ def layout(query_string):
                                 {"label": "Run start date",
                                 "value": "start_date"},
                                 {"label": "Run end date",
-                                "value": "end_date"}
+                                "value": "completion_date"}
                         ]
                     ),
 
@@ -452,7 +453,7 @@ def init_callbacks(dash_app):
             State(ids['insert-size-median-cutoff'], 'value'),
             State(ids['passed-filter-reads-cutoff'], 'value'),
             State(ids["date-range"], 'start_date'),
-            State(ids["date-range"], 'end_date'),
+            State(ids["date-range"], 'completion_date'),
             State('url', 'search'),
         ]
     )
@@ -474,7 +475,7 @@ def init_callbacks(dash_app):
             insert_median_cutoff,
             total_reads_cutoff,
             start_date,
-            end_date,
+            completion_date,
             search_query):
         log_utils.log_filters(locals(), collapsing_functions, logger)
         if searchsample and searchsampleext:
@@ -482,7 +483,7 @@ def init_callbacks(dash_app):
         elif not searchsample and searchsampleext:
             searchsample = searchsampleext
         df = reshape_single_lane_df(bamqc, runs, instruments, projects, references, kits, library_designs,
-                                    start_date, end_date, first_sort, second_sort, colour_by,
+                                    start_date, completion_date, first_sort, second_sort, colour_by,
                                     shape_by, shape_colour.items_for_df(), searchsample)
 
         (approve_run_href, approve_run_style) = sidebar_utils.approve_run_url(runs)

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -253,7 +253,7 @@ def layout(query_string):
     df = reshape_single_lane_df(bamqc, initial["runs"], initial["instruments"],
                                 initial["projects"], initial["references"], initial["kits"],
                                 initial["library_designs"], initial["start_date"],
-                                initial["completion_date"], initial["first_sort"],
+                                initial["end_date"], initial["first_sort"],
                                 initial["second_sort"], initial["colour_by"],
                                 initial["shape_by"], shape_colour.items_for_df(), [])
 
@@ -453,7 +453,7 @@ def init_callbacks(dash_app):
             State(ids['insert-size-median-cutoff'], 'value'),
             State(ids['passed-filter-reads-cutoff'], 'value'),
             State(ids["date-range"], 'start_date'),
-            State(ids["date-range"], 'completion_date'),
+            State(ids["date-range"], 'end_date'),
             State('url', 'search'),
         ]
     )
@@ -475,7 +475,7 @@ def init_callbacks(dash_app):
             insert_median_cutoff,
             total_reads_cutoff,
             start_date,
-            completion_date,
+            end_date,
             search_query):
         log_utils.log_filters(locals(), collapsing_functions, logger)
         if searchsample and searchsampleext:
@@ -483,7 +483,7 @@ def init_callbacks(dash_app):
         elif not searchsample and searchsampleext:
             searchsample = searchsampleext
         df = reshape_single_lane_df(bamqc, runs, instruments, projects, references, kits, library_designs,
-                                    start_date, completion_date, first_sort, second_sort, colour_by,
+                                    start_date, end_date, first_sort, second_sort, colour_by,
                                     shape_by, shape_colour.items_for_df(), searchsample)
 
         (approve_run_href, approve_run_style) = sidebar_utils.approve_run_url(runs)


### PR DESCRIPTION
- Only on Single-Lane TS for now
- the pdb breakpoint (_set_trace()_) in plot_builder is for demonstrating that the dataframe does indeed sort by date after the sort is run. Comment out the if and the breakpoint if you don't want to use pdb
- Available as both First and Second sort because I didn't know which would be better
- Available as Data Label for verifying that no sort happens in front end