### PR TITLE
Rename Approve Run button to View Run

### DIFF
--- a/application/dash_application/utility/sidebar_utils.py
+++ b/application/dash_application/utility/sidebar_utils.py
@@ -88,7 +88,7 @@ def runs_in_range(start_date: str, end_date: str) -> Series:
 
 
 def approve_run_button(approve_run_id: str) -> html.A:
-    return html.A("Approve this run in MISO",
+    return html.A("View Run in MISO",
                   id=approve_run_id,
                   className="button approve-run",
                   target="_blank",


### PR DESCRIPTION
The workflow for approving Runs has changed and doesn't really look at Dashi any more. Preserve the button, but rename to 'View' rather than 'Approve'. This will also limit confusion when we add the QC Library Aliquots button nearby.