### PR TITLE
[GR-1217] Replace BamQC's TotalReads with FastQC's TotalSequences in Single-Lane Reports

### DIFF
--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -370,14 +370,15 @@ def get_runs():
 
 def df_with_fastqc_data(df, merge_cols):
     fastqc = get_fastqc()
-    fastqc = fastqc.loc[fastqc[FASTQC_COL.ReadNumber] == 1]
-    return df.merge(
+    df_with_fastqc = df.merge(
         fastqc,
         how="left",
         left_on=merge_cols,
         right_on=[FASTQC_COL.Run, FASTQC_COL.Lane, FASTQC_COL.Barcodes],
         suffixes=('', '_q')
     )
+    df_with_fastqc.groupby([FASTQC_COL.Run, FASTQC_COL.Lane, FASTQC_COL.Barcodes])[FASTQC_COL.TotalSequences].sum().reset_index()
+    return df_with_fastqc
 
 def df_with_pinery_samples_ius(df: DataFrame, pinery_samples: DataFrame, ius_cols:
                            List[str]):

--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -368,6 +368,14 @@ def get_pinery_merged_samples(active_projects_only=True):
 def get_runs():
     return _runs_with_instruments.copy(deep=True)
 
+def df_with_fastqc_data(df, merge_cols):
+    return df.merge(
+        get_fastqc(),
+        how="left",
+        left_on=merge_cols,
+        right_on=[FASTQC_COL.Run, FASTQC_COL.Lane],
+        suffixes=('', '_q')
+    )
 
 def df_with_pinery_samples_ius(df: DataFrame, pinery_samples: DataFrame, ius_cols:
                            List[str]):

--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -369,8 +369,10 @@ def get_runs():
     return _runs_with_instruments.copy(deep=True)
 
 def df_with_fastqc_data(df, merge_cols):
+    fastqc = get_fastqc()
+    fastqc = fastqc.loc[fastqc[FASTQC_COL.ReadNumber] == 1]
     return df.merge(
-        get_fastqc(),
+        fastqc,
         how="left",
         left_on=merge_cols,
         right_on=[FASTQC_COL.Run, FASTQC_COL.Lane, FASTQC_COL.Barcodes],

--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -370,6 +370,7 @@ def get_runs():
 
 def df_with_fastqc_data(df, merge_cols):
     fastqc = get_fastqc()
+    fastqc = fastqc.groupby([FASTQC_COL.Run, FASTQC_COL.Lane, FASTQC_COL.Barcodes])[FASTQC_COL.TotalSequences].sum().reset_index()
     df_with_fastqc = df.merge(
         fastqc,
         how="left",
@@ -377,7 +378,6 @@ def df_with_fastqc_data(df, merge_cols):
         right_on=[FASTQC_COL.Run, FASTQC_COL.Lane, FASTQC_COL.Barcodes],
         suffixes=('', '_q')
     )
-    df_with_fastqc.groupby([FASTQC_COL.Run, FASTQC_COL.Lane, FASTQC_COL.Barcodes])[FASTQC_COL.TotalSequences].sum().reset_index()
     return df_with_fastqc
 
 def df_with_pinery_samples_ius(df: DataFrame, pinery_samples: DataFrame, ius_cols:

--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -373,7 +373,7 @@ def df_with_fastqc_data(df, merge_cols):
         get_fastqc(),
         how="left",
         left_on=merge_cols,
-        right_on=[FASTQC_COL.Run, FASTQC_COL.Lane],
+        right_on=[FASTQC_COL.Run, FASTQC_COL.Lane, FASTQC_COL.Barcodes],
         suffixes=('', '_q')
     )
 

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -118,6 +118,8 @@ def get_bamqc_data():
 
 (bamqc, DATAVERSION) = get_bamqc_data()
 
+# TODO: Does 'Total Sequences' get subbed in at lines 93+ for TotalReads? The others aren't represented in fastqc
+fastqc = util.filter_by_library_design(util.df_with_instrument_model(util.df_with_pinery_samples_ius(get_fastqc(), pinery_samples, util.bamqc3_ius_columns), PINERY_COL.SequencerRunName), util.ex_lib_designs)
 
 # Build lists of attributes for sorting, shaping, and filtering on
 ALL_PROJECTS = util.unique_set(bamqc, PINERY_COL.StudyTitle)

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -8,7 +8,7 @@ from ..utility.table_builder import table_tabs_single_lane, cutoff_table_data_iu
 from ..utility import df_manipulation as util
 from ..utility import sidebar_utils
 from ..utility import log_utils
-from gsiqcetl.column import BamQc3Column
+from gsiqcetl.column import BamQc3Column, FastqcColumn
 import pinery
 import logging
 
@@ -61,9 +61,11 @@ ids = init_ids([
 ])
 
 BAMQC_COL = BamQc3Column
+FASTQC_COL = FastqcColumn
 PINERY_COL = pinery.column.SampleProvenanceColumn
 INSTRUMENT_COLS = pinery.column.InstrumentWithModelColumn
 RUN_COLS = pinery.column.RunsColumn
+
 
 special_cols = {
     "Total Reads (Passed Filter)": "Total Reads PassedFilter",
@@ -88,16 +90,24 @@ initial[cutoff_insert_median] = 150
 
 def get_bamqc_data():
     bamqc_df = util.get_bamqc3_and_4()
+    bamqc_df = bamqc_df.merge(
+        util.get_fastqc(),
+        how="left",
+        left_on=[BAMQC_COL.Run, BAMQC_COL.Lane],
+        right_on=[FASTQC_COL.Run, FASTQC_COL.Lane],
+        suffixes=('', '_q')
+    )
+
     bamqc_df[special_cols["Total Reads (Passed Filter)"]] = round(
         bamqc_df[BAMQC_COL.TotalReads] / 1e6, 3)
     bamqc_df[special_cols["On Target Reads (%)"]] = sidebar_utils.percentage_of(
-        bamqc_df, BAMQC_COL.ReadsOnTarget, BAMQC_COL.TotalReads
+        bamqc_df, BAMQC_COL.ReadsOnTarget, FASTQC_COL.TotalSequences
     )
     bamqc_df[special_cols["Unmapped Reads (%)"]] = sidebar_utils.percentage_of(
-        bamqc_df, BAMQC_COL.UnmappedReads, BAMQC_COL.TotalReads
+        bamqc_df, BAMQC_COL.UnmappedReads, FASTQC_COL.TotalSequences
     )
     bamqc_df[special_cols["Non-Primary Reads (%)"]] = sidebar_utils.percentage_of(
-        bamqc_df, BAMQC_COL.NonPrimaryReads, BAMQC_COL.TotalReads
+        bamqc_df, BAMQC_COL.NonPrimaryReads, FASTQC_COL.TotalSequences
     )
     bamqc_df[special_cols["Coverage per Gb"]] = round(
         bamqc_df[BAMQC_COL.CoverageDeduplicated] / (
@@ -117,9 +127,6 @@ def get_bamqc_data():
 
 
 (bamqc, DATAVERSION) = get_bamqc_data()
-
-# TODO: Does 'Total Sequences' get subbed in at lines 93+ for TotalReads? The others aren't represented in fastqc
-fastqc = util.filter_by_library_design(util.df_with_instrument_model(util.df_with_pinery_samples_ius(get_fastqc(), pinery_samples, util.bamqc3_ius_columns), PINERY_COL.SequencerRunName), util.ex_lib_designs)
 
 # Build lists of attributes for sorting, shaping, and filtering on
 ALL_PROJECTS = util.unique_set(bamqc, PINERY_COL.StudyTitle)

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -90,13 +90,7 @@ initial[cutoff_insert_median] = 150
 
 def get_bamqc_data():
     bamqc_df = util.get_bamqc3_and_4()
-    bamqc_df = bamqc_df.merge(
-        util.get_fastqc(),
-        how="left",
-        left_on=[BAMQC_COL.Run, BAMQC_COL.Lane],
-        right_on=[FASTQC_COL.Run, FASTQC_COL.Lane],
-        suffixes=('', '_q')
-    )
+    bamqc_df = util.df_with_fastqc_data(bamqc_df, [BAMQC_COL.Run, BAMQC_COL.Lane])
 
     bamqc_df[special_cols["Total Reads (Passed Filter)"]] = round(
         bamqc_df[BAMQC_COL.TotalReads] / 1e6, 3)

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -78,7 +78,7 @@ special_cols = {
 initial = get_initial_single_lane_values()
 
 # Set additional initial values for dropdown menus
-initial["second_sort"] = BAMQC_COL.TotalReads
+initial["second_sort"] = FASTQC_COL.TotalSequences
 # Set initial values for graph cutoff lines
 cutoff_pf_reads_label = "Total PF Reads minimum"
 cutoff_pf_reads = "cutoff_pf_reads"
@@ -93,7 +93,7 @@ def get_bamqc_data():
     bamqc_df = util.df_with_fastqc_data(bamqc_df, [BAMQC_COL.Run, BAMQC_COL.Lane, BAMQC_COL.Barcodes])
 
     bamqc_df[special_cols["Total Reads (Passed Filter)"]] = round(
-        bamqc_df[BAMQC_COL.TotalReads] / 1e6, 3)
+        bamqc_df[FASTQC_COL.TotalSequences] / 1e6, 3)
     bamqc_df[special_cols["On Target Reads (%)"]] = sidebar_utils.percentage_of(
         bamqc_df, BAMQC_COL.ReadsOnTarget, FASTQC_COL.TotalSequences
     )
@@ -105,7 +105,7 @@ def get_bamqc_data():
     )
     bamqc_df[special_cols["Coverage per Gb"]] = round(
         bamqc_df[BAMQC_COL.CoverageDeduplicated] / (
-                bamqc_df[BAMQC_COL.TotalReads] *
+                bamqc_df[FASTQC_COL.TotalSequences] *
                 bamqc_df[BAMQC_COL.AverageReadLength] / 1e9)
         , 3)
 
@@ -167,7 +167,7 @@ bamqc = add_graphable_cols(bamqc, initial, shape_colour.items_for_df())
 
 SORT_BY = sidebar_utils.default_first_sort + [
     {"label": "Total Reads",
-     "value": BAMQC_COL.TotalReads},
+     "value": FASTQC_COL.TotalSequences},
     {"label": "Unmapped Reads",
      "value": special_cols["Unmapped Reads (%)"]},
     {"label": "Non-primary Reads",

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -90,7 +90,7 @@ initial[cutoff_insert_median] = 150
 
 def get_bamqc_data():
     bamqc_df = util.get_bamqc3_and_4()
-    bamqc_df = util.df_with_fastqc_data(bamqc_df, [BAMQC_COL.Run, BAMQC_COL.Lane])
+    bamqc_df = util.df_with_fastqc_data(bamqc_df, [BAMQC_COL.Run, BAMQC_COL.Lane, BAMQC_COL.Barcodes])
 
     bamqc_df[special_cols["Total Reads (Passed Filter)"]] = round(
         bamqc_df[BAMQC_COL.TotalReads] / 1e6, 3)


### PR DESCRIPTION
Holding off on Call-Ready reports until merging the data is figured out.

Savo: please try different merge types and let me know how you feel about displaying FastQC data before it can be merged with BamQC, as discussed in our meeting.