### PR TITLE
[GR-1235] Call ready views use clusters instead of reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and as of version 1.0.0, follows semantic versioning.
 ## Changed
   * Add clusters-per-sample thresholds
   * 'Missing' info no longer appears in Failed Samples table
+  * Bumped gsi-qc-etl to 0.41.0
+  * Call ready graphs new use clusters instead of reads
+  * Single lane TS cutoffs were switched to clusters
 
 ## [200928-1530] - 2020-09-28
 ## Changed

--- a/application/dash_application/utility/sidebar_utils.py
+++ b/application/dash_application/utility/sidebar_utils.py
@@ -12,7 +12,6 @@ import pinery.column
 import gsiqcetl.column
 from . import df_manipulation as df_tools
 
-total_clusters_cutoff_label = "Passed Filter Clusters (* 10^6) minimum"
 insert_mean_cutoff_label = "Mean Insert Size minimum"
 insert_median_cutoff_label = "Median Insert Size minimum"
 percent_duplication_cutoff_label = "% Duplication maximum"

--- a/application/dash_application/utility/sidebar_utils.py
+++ b/application/dash_application/utility/sidebar_utils.py
@@ -12,7 +12,7 @@ import pinery.column
 import gsiqcetl.column
 from . import df_manipulation as df_tools
 
-total_reads_cutoff_label = "Passed Filter Reads (* 10^6) minimum"
+total_clusters_cutoff_label = "Passed Filter Clusters (* 10^6) minimum"
 insert_mean_cutoff_label = "Mean Insert Size minimum"
 insert_median_cutoff_label = "Median Insert Size minimum"
 percent_duplication_cutoff_label = "% Duplication maximum"

--- a/application/dash_application/views/call_ready_ts.py
+++ b/application/dash_application/views/call_ready_ts.py
@@ -81,6 +81,7 @@ special_cols = {
     "Total Bait Bases": "Total bait bases",
     "On Bait Percentage": "On Bait Percentage",
     "Near Bait Percentage": "Near Bait Percentage",
+    "Total Clusters (Passed Filter)": "Total Clusters",
 }
 
 
@@ -112,6 +113,8 @@ def get_merged_ts_data():
 
     bamqc3_df[special_cols["Total Reads (Passed Filter)"]] = round(
         bamqc3_df[BAMQC_COL.TotalReads] / 1e6, 3)
+    bamqc3_df[special_cols["Total Clusters (Passed Filter)"]] = round(
+        bamqc3_df[BAMQC_COL.TotalClusters] / 1e6, 3)
     bamqc3_df[special_cols["Percent Unique Reads (PF)"]] = round(
         bamqc3_df[BAMQC_COL.NonPrimaryReads] / bamqc3_df[
             BAMQC_COL.TotalReads], 3)
@@ -169,12 +172,12 @@ ts_table_columns = TS_DF.columns
 initial = get_initial_call_ready_values()
 
 # Set additional initial values for dropdown menus
-initial["second_sort"] = BAMQC_COL.TotalReads
+initial["second_sort"] = BAMQC_COL.TotalClusters
 # Set initial values for graph cutoff lines
-cutoff_pf_reads_tumour_label = "Total PF Reads (Tumour) minimum"
-initial["cutoff_pf_reads_tumour"] = 148
-cutoff_pf_reads_normal_label = "Total PF Reads (Normal) minimum"
-initial["cutoff_pf_reads_normal"] = 44
+cutoff_pf_clusters_tumour_label = "Total PF Reads (Tumour) minimum"
+initial["cutoff_pf_clusters_tumour"] = 74
+cutoff_pf_clusters_normal_label = "Total PF Reads (Normal) minimum"
+initial["cutoff_pf_clusters_normal"] = 22
 cutoff_coverage_tumour_label = "Coverage (Tumour) minimum"
 initial["cutoff_coverage_tumour"] = 80
 cutoff_coverage_normal_label = "Coverage (Normal) minimum"
@@ -212,8 +215,8 @@ shape_colour = ColourShapeCallReady(
 TS_DF = add_graphable_cols(TS_DF, initial, shape_colour.items_for_df(), None, True)
 
 SORT_BY = shape_colour.dropdown() + [
-    {"label": "Total Reads",
-     "value": BAMQC_COL.TotalReads},
+    {"label": "Total Clusters",
+     "value": BAMQC_COL.TotalClusters},
     {"label": "Median Target Coverage",
      "value": HSMETRICS_COL.MedianTargetCoverage},
     {"label": "Callability",
@@ -238,17 +241,17 @@ SORT_BY = shape_colour.dropdown() + [
      "value": util.ml_col}
 ]
 
-def generate_total_reads(df, graph_params):
+def generate_total_clusters(df, graph_params):
     return CallReadySubplot(
-        "Total Reads (Passed Filter)",
+        "Total Clusters (Passed Filter)",
         df,
-        lambda d: d[special_cols["Total Reads (Passed Filter)"]],
+        lambda d: d[special_cols["Total Clusters (Passed Filter)"]],
         "# PF Reads X 10^6",
         graph_params["colour_by"],
         graph_params["shape_by"],
         graph_params["shownames_val"],
-        cutoff_lines=[(cutoff_pf_reads_normal_label, graph_params["cutoff_pf_reads_normal"]),
-         (cutoff_pf_reads_tumour_label, graph_params["cutoff_pf_reads_tumour"])]
+        cutoff_lines=[(cutoff_pf_clusters_normal_label, graph_params["cutoff_pf_clusters_normal"]),
+         (cutoff_pf_clusters_tumour_label, graph_params["cutoff_pf_clusters_tumour"])]
     )
 
 
@@ -375,7 +378,7 @@ def generate_bait(df):
 
 
 GRAPHS = [
-    generate_total_reads,
+    generate_total_clusters,
     generate_median_target_coverage,
     generate_callability,
     generate_median_insert_size,
@@ -464,10 +467,10 @@ def layout(query_string):
                     sidebar_utils.hr(),
 
                     # Cutoffs
-                    sidebar_utils.cutoff_input("{} (*10^6)".format(cutoff_pf_reads_tumour_label),
-                                               ids["pf-tumour-cutoff"], initial["cutoff_pf_reads_tumour"]),
-                    sidebar_utils.cutoff_input("{} (*10^6)".format(cutoff_pf_reads_normal_label),
-                                               ids["pf-normal-cutoff"], initial["cutoff_pf_reads_normal"]),
+                    sidebar_utils.cutoff_input("{} (*10^6)".format(cutoff_pf_clusters_tumour_label),
+                                               ids["pf-tumour-cutoff"], initial["cutoff_pf_clusters_tumour"]),
+                    sidebar_utils.cutoff_input("{} (*10^6)".format(cutoff_pf_clusters_normal_label),
+                                               ids["pf-normal-cutoff"], initial["cutoff_pf_clusters_normal"]),
                     sidebar_utils.cutoff_input(cutoff_coverage_tumour_label,
                                                ids["tumour-coverage-cutoff"], initial["cutoff_coverage_tumour"]),
                     sidebar_utils.cutoff_input(cutoff_coverage_normal_label,
@@ -507,11 +510,11 @@ def layout(query_string):
                                 df,
                                 ts_table_columns,
                                 [
-                                    (cutoff_pf_reads_tumour_label, special_cols["Total Reads (Passed Filter)"],
-                                    initial["cutoff_pf_reads_tumour"],
+                                    (cutoff_pf_clusters_tumour_label, special_cols["Total Clusters (Passed Filter)"],
+                                    initial["cutoff_pf_clusters_tumour"],
                                     (lambda row, col, cutoff: row[col] < cutoff and util.is_tumour(row))),
-                                    (cutoff_pf_reads_normal_label, special_cols["Total Reads (Passed Filter)"],
-                                    initial["cutoff_pf_reads_normal"],
+                                    (cutoff_pf_clusters_normal_label, special_cols["Total Clusters (Passed Filter)"],
+                                    initial["cutoff_pf_clusters_normal"],
                                     (lambda row, col, cutoff: row[col] < cutoff and util.is_normal(row))),
                                     (cutoff_coverage_tumour_label, HSMETRICS_COL.MedianTargetCoverage,
                                     initial["cutoff_coverage_tumour"],
@@ -611,16 +614,16 @@ def init_callbacks(dash_app):
             "cutoff_duplicate_rate": duplicate_rate_max,
             "cutoff_callability": callability_cutoff,
             "cutoff_insert_median": insert_size_cutoff,
-            "cutoff_pf_reads_tumour": pf_tumour_cutoff,
-            "cutoff_pf_reads_normal": pf_normal_cutoff
+            "cutoff_pf_clusters_tumour": pf_tumour_cutoff,
+            "cutoff_pf_clusters_normal": pf_normal_cutoff
         }
 
         dd = defaultdict(list)
         (failure_df, failure_columns) = cutoff_table_data_merged(df, [
-            (cutoff_pf_reads_tumour_label, special_cols["Total Reads (Passed Filter)"],
+            (cutoff_pf_clusters_tumour_label, special_cols["Total Clusters (Passed Filter)"],
              pf_tumour_cutoff,
              (lambda row, col, cutoff: row[col] < cutoff if util.is_tumour(row) else None)),
-            (cutoff_pf_reads_normal_label, special_cols["Total Reads (Passed Filter)"],
+            (cutoff_pf_clusters_normal_label, special_cols["Total Clusters (Passed Filter)"],
              pf_normal_cutoff,
              (lambda row, col, cutoff: row[col] < cutoff if util.is_normal(row) else None)),
             (cutoff_coverage_tumour_label, HSMETRICS_COL.MedianTargetCoverage, tumour_coverage_cutoff,

--- a/application/dash_application/views/call_ready_wgs.py
+++ b/application/dash_application/views/call_ready_wgs.py
@@ -77,7 +77,8 @@ special_cols = {
     "Percent Callability": "percent callability",
     "File SWID MutectCallability": "File SWID MutectCallability",
     "File SWID BamQC3": "File SWID BamQC3",
-    "Tumor Purity (%)": "tumor purity percentage"
+    "Tumor Purity (%)": "tumor purity percentage",
+    "Total Clusters (Passed Filter)": "Total Clusters",
 }
 
 
@@ -113,6 +114,8 @@ def get_merged_wgs_data():
         callability_df[CALL_COL.Callability] * 100.0, 3)
     bamqc3_df[special_cols["Total Reads (Passed Filter)"]] = round(
         bamqc3_df[BAMQC_COL.TotalReads] / 1e6, 3)
+    bamqc3_df[special_cols["Total Clusters (Passed Filter)"]] = round(
+        bamqc3_df[BAMQC_COL.TotalClusters] / 1e6, 3)
     bamqc3_df[special_cols["Unique Reads (Passed Filter)"]] = (1 - (
                 bamqc3_df[BAMQC_COL.NonPrimaryReads] /
                 bamqc3_df[BAMQC_COL.TotalReads])) * 100
@@ -167,7 +170,7 @@ wgs_table_columns = WGS_DF.columns
 initial = get_initial_call_ready_values()
 
 # Set additional initial values for dropdown menus
-initial["second_sort"] = BAMQC_COL.TotalReads
+initial["second_sort"] = BAMQC_COL.TotalClusters
 # Set initial values for graph cutoff lines
 # Sourced from https://docs.google.com/document/d/1L056bikfIJDeX6Qzo6fwBb9j7A5NgC6o/edit
 # TODO: This is supposed to depend on Coverage being 80x/30x?
@@ -222,8 +225,8 @@ WGS_DF = add_graphable_cols(WGS_DF, initial, shape_colour.items_for_df(), None,
 
 SORT_BY = shape_colour.dropdown() + [
     {
-        "label": "Total Reads (Passed Filter)",
-        "value": BAMQC_COL.TotalReads
+        "label": "Total Clusters (Passed Filter)",
+        "value": BAMQC_COL.TotalClusters
     },
     {
         "label": "Coverage (Deduplicated)",
@@ -256,11 +259,11 @@ SORT_BY = shape_colour.dropdown() + [
 ]
 
 
-def generate_total_reads(df, graph_params):
+def generate_total_clusters(df, graph_params):
     return CallReadySubplot(
-        "Total Reads (Passed Filter)",
+        "Total Clusters (Passed Filter)",
         df,
-        lambda d: d[special_cols["Total Reads (Passed Filter)"]],
+        lambda d: d[special_cols["Total Clusters (Passed Filter)"]],
         "# PF Reads X 10^6",
         graph_params["colour_by"],
         graph_params["shape_by"],
@@ -378,7 +381,7 @@ def generate_unmapped_reads(df, graph_params):
 
 
 GRAPHS = [
-    generate_total_reads,
+    generate_total_clusters,
     generate_deduplicated_coverage,
     generate_deduplicated_coverage_per_gb,
     generate_median_coverage,

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -47,7 +47,7 @@ ids = init_ids([
     'show-data-labels',
     'show-all-data-labels',
     'insert-size-median-cutoff',
-    'passed-filter-reads-cutoff',
+    'passed-filter-clusters-cutoff',
     "date-range",
 
     #Graphs
@@ -82,8 +82,8 @@ initial = get_initial_single_lane_values()
 # Set additional initial values for dropdown menus
 initial["second_sort"] = special_cols["Total Clusters (Passed Filter)"]
 # Set initial values for graph cutoff lines
-cutoff_pf_reads_label = sidebar_utils.total_reads_cutoff_label
-initial["cutoff_pf_reads"] = 0.01
+cutoff_pf_clusters_label = sidebar_utils.total_clusters_cutoff_label
+initial["cutoff_pf_clusters"] = 0.01
 cutoff_insert_median_label = sidebar_utils.insert_median_cutoff_label
 initial["cutoff_insert_median"] = 150
 
@@ -193,7 +193,7 @@ def generate_total_clusters(df, graph_params):
         graph_params["colour_by"],
         graph_params["shape_by"],
         graph_params["shownames_val"],
-        cutoff_lines=[(cutoff_pf_reads_label, graph_params["cutoff_pf_reads"])]
+        cutoff_lines=[(cutoff_pf_clusters_label, graph_params["cutoff_pf_clusters"])]
     )
 
 
@@ -390,8 +390,8 @@ def layout(query_string):
                     sidebar_utils.hr(),
 
                     # Cutoffs
-                    sidebar_utils.cutoff_input(cutoff_pf_reads_label,
-                        ids['passed-filter-reads-cutoff'], initial["cutoff_pf_reads"]),
+                    sidebar_utils.cutoff_input(cutoff_pf_clusters_label,
+                        ids['passed-filter-clusters-cutoff'], initial["cutoff_pf_clusters"]),
                     sidebar_utils.cutoff_input(cutoff_insert_median_label,
                         ids['insert-size-median-cutoff'], initial["cutoff_insert_median"]),
                     
@@ -421,8 +421,8 @@ def layout(query_string):
                                 [
                                     (cutoff_insert_median_label, BAMQC_COL.InsertMedian, initial["cutoff_insert_median"],
                                     (lambda row, col, cutoff: row[col] < cutoff)),
-                                    (cutoff_pf_reads_label,
-                                    special_cols["Total Reads (Passed Filter)"], initial["cutoff_pf_reads"],
+                                    (cutoff_pf_clusters_label,
+                                    special_cols["Total Clusters (Passed Filter)"], initial["cutoff_pf_clusters"],
                                     (lambda row, col, cutoff: row[col] < cutoff)),
                                 ]
                             ),
@@ -467,7 +467,7 @@ def init_callbacks(dash_app):
             State(ids['search-sample-ext'], 'value'),
             State(ids['show-data-labels'], 'value'),
             State(ids['insert-size-median-cutoff'], 'value'),
-            State(ids['passed-filter-reads-cutoff'], 'value'),
+            State(ids['passed-filter-clusters-cutoff'], 'value'),
             State(ids["date-range"], 'start_date'),
             State(ids["date-range"], 'end_date'),
             State('url', 'search'),
@@ -489,7 +489,7 @@ def init_callbacks(dash_app):
             searchsampleext,
             show_names,
             insert_median_cutoff,
-            total_reads_cutoff,
+            total_clusters_cutoff,
             start_date,
             end_date,
             search_query):
@@ -508,7 +508,7 @@ def init_callbacks(dash_app):
             "colour_by": colour_by,
             "shape_by": shape_by,
             "shownames_val": show_names,
-            "cutoff_pf_reads": total_reads_cutoff,
+            "cutoff_pf_clusters": total_clusters_cutoff,
             "cutoff_insert_median": insert_median_cutoff
         }
 
@@ -516,8 +516,8 @@ def init_callbacks(dash_app):
         (failure_df, failure_columns ) = cutoff_table_data_ius(df, [
                 (cutoff_insert_median_label, BAMQC_COL.InsertMedian, insert_median_cutoff,
                  (lambda row, col, cutoff: row[col] < cutoff)),
-                (cutoff_pf_reads_label, special_cols["Total Reads (Passed "
-                                                    "Filter)"], total_reads_cutoff,
+                (cutoff_pf_clusters_label, special_cols["Total Clusters (Passed "
+                                                    "Filter)"], total_clusters_cutoff,
                  (lambda row, col, cutoff: row[col] < cutoff)),
             ])
         new_search_sample = util.unique_set(df, PINERY_COL.SampleName)

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -82,7 +82,7 @@ initial = get_initial_single_lane_values()
 # Set additional initial values for dropdown menus
 initial["second_sort"] = special_cols["Total Clusters (Passed Filter)"]
 # Set initial values for graph cutoff lines
-cutoff_pf_clusters_label = sidebar_utils.total_clusters_cutoff_label
+cutoff_pf_clusters_label = sidebar_utils.clusters_per_sample_cutoff_label
 initial["cutoff_pf_clusters"] = 0.01
 cutoff_insert_median_label = sidebar_utils.insert_median_cutoff_label
 initial["cutoff_insert_median"] = 150

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pandas>=1.0.1
 Flask>=1.1.1
 dash==1.13.3
 prometheus_flask_exporter>=0.11.0
-git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v0.40.0
+git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v0.41.0
 sd-material-ui>=3.1.2
 scipy>=1.2.0
 python-dotenv>=0.10.3


### PR DESCRIPTION
I will update Wiki.

Also fixed up Single Lane TS to remove Total Read vestiges as pointed out in https://github.com/oicr-gsi/dashi/pull/273#discussion_r498838582