### PR TITLE
[GR-1251] Fix data lables and allow sort by run date

### DIFF
--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -418,19 +418,22 @@ def df_with_pinery_samples_merged(df: DataFrame, pinery_samples: DataFrame,
     return df
 
 
-def df_with_instrument_model(df: DataFrame, run_col: str):
+def df_with_run_info(df: DataFrame, run_col: str):
     """Add the instrument model column to a DataFrame."""
     r_i = _runs_with_instruments.copy(deep=True)
     return df.merge(
-        r_i[[INSTRUMENTS_COL.ModelName, INSTRUMENTS_COL.Platform,
-             RUN_COL.Name]],
+        r_i[[
+            INSTRUMENTS_COL.ModelName,
+            INSTRUMENTS_COL.Platform,
+            RUN_COL.Name,
+            pinery.column.RunsColumn.StartDate,
+            pinery.column.RunsColumn.CompletionDate,
+        ]],
         how="left",
         left_on=run_col,
         right_on=[RUN_COL.Name]
     )
 
-def df_with_runs(df):
-    return pandas.merge(df, get_runs(), left_on=PINERY_COL.SequencerRunName, right_on='name')
 
 def filter_by_library_design(df: DataFrame, library_designs: List[str],
                              ld_col=PINERY_COL.LibrarySourceTemplateType):

--- a/application/dash_application/utility/sidebar_utils.py
+++ b/application/dash_application/utility/sidebar_utils.py
@@ -3,12 +3,12 @@ import re
 import urllib.parse
 import json
 import os
-from typing import List, Dict, Tuple, Union
+from typing import List, Dict, Union
 
 import dash_core_components as core
 import dash_html_components as html
 from dash.exceptions import PreventUpdate
-from pandas import DataFrame, Series, Timestamp
+from pandas import Series, Timestamp
 
 import pinery.column
 import gsiqcetl.column
@@ -22,6 +22,7 @@ rrna_contamination_cutoff_label = "rRNA Contamination maximum"
 
 
 PINERY_COL = pinery.column.SampleProvenanceColumn
+RUNS_COL = pinery.column.RunsColumn
 COMMON_COL = gsiqcetl.column.ColumnNames
 ALL_RUNS = df_tools.get_runs()
 
@@ -286,8 +287,8 @@ def show_data_labels_input_single_lane(
             {'label': 'Tissue Origin', 'value': PINERY_COL.TissueOrigin},
             {'label': 'Tissue Preparation', 'value': PINERY_COL.TissuePreparation},
             {'label': 'Tissue Type', 'value': PINERY_COL.TissueType},
-            {'label': 'Run start date', 'value': 'start_date'},
-            {'label': 'Run end date', 'value': 'completion_date'},
+            {'label': 'Run Start Date', 'value': RUNS_COL.StartDate},
+            {'label': 'Run End Date', 'value': RUNS_COL.CompletionDate},
         ])
 
 

--- a/application/dash_application/views/SARS-CoV-2.py
+++ b/application/dash_application/views/SARS-CoV-2.py
@@ -79,6 +79,7 @@ ids = init_ids([
 
 PINERY_COL = pinery.column.SampleProvenanceColumn
 INSTRUMENT_COLS = pinery.column.InstrumentWithModelColumn
+RUN_COLS = pinery.column.RunsColumn
 
 pinery_samples = util.get_pinery_samples()
 SAMTOOLS_STATS_COV2_HUMAN_DF = util.get_samtools_stats_cov2_human()
@@ -134,11 +135,11 @@ BEDTOOLS_DF = util.df_with_pinery_samples_ius(BEDTOOLS_DF, pinery_samples, util.
 ALL_PROJECTS = util.unique_set(BEDTOOLS_DF, PINERY_COL.StudyTitle)
 ALL_KITS = util.unique_set(BEDTOOLS_DF, PINERY_COL.PrepKit)
 
-BEDTOOLS_DF = util.df_with_instrument_model(BEDTOOLS_DF, PINERY_COL.SequencerRunName)
+BEDTOOLS_DF = util.df_with_run_info(BEDTOOLS_DF, PINERY_COL.SequencerRunName)
 ILLUMINA_INSTRUMENT_MODELS = util.get_illumina_instruments(BEDTOOLS_DF)
 BEDTOOLS_DF = BEDTOOLS_DF[BEDTOOLS_DF[INSTRUMENT_COLS.ModelName].isin(ILLUMINA_INSTRUMENT_MODELS)]
 
-BEDTOOLS_PERCENTILE_DF = util.df_with_instrument_model(BEDTOOLS_PERCENTILE_DF, PINERY_COL.SequencerRunName)
+BEDTOOLS_PERCENTILE_DF = util.df_with_run_info(BEDTOOLS_PERCENTILE_DF, PINERY_COL.SequencerRunName)
 BEDTOOLS_PERCENTILE_DF = BEDTOOLS_PERCENTILE_DF[BEDTOOLS_PERCENTILE_DF[INSTRUMENT_COLS.ModelName].isin(ILLUMINA_INSTRUMENT_MODELS)]
 
 
@@ -217,7 +218,11 @@ SORT_BY = [
     {"label": "Covid Mapped (% of total reads)",
      "value": "covid_percent_mapped_total"},
     {"label": "Sample Name",
-     "value": PINERY_COL.SampleName}
+     "value": PINERY_COL.SampleName},
+    {"label": "Run Start Date",
+     "value": RUN_COLS.StartDate},
+    {"label": "Run End Date",
+     "value": RUN_COLS.CompletionDate},
 ]
 
 

--- a/application/dash_application/views/single_lane_cfmedip.py
+++ b/application/dash_application/views/single_lane_cfmedip.py
@@ -110,7 +110,7 @@ def get_cfmedip_data():
 
     cfmedip_df = util.df_with_pinery_samples_ius(cfmedip_df, pinery_samples, util.cfmedip_ius_columns)
 
-    cfmedip_df = util.df_with_instrument_model(cfmedip_df, PINERY_COL.SequencerRunName)
+    cfmedip_df = util.df_with_run_info(cfmedip_df, PINERY_COL.SequencerRunName)
 
     return cfmedip_df, util.cache.versions(["cfmedipqc"])
 
@@ -186,7 +186,11 @@ SORT_BY = sidebar_utils.default_first_sort + [
     {"label": "PERCENT_DUPLICATION",
      "value": CFMEDIP_COL.PercentDuplication},
     {"label": "Sample Name",
-     "value": PINERY_COL.SampleName}
+     "value": PINERY_COL.SampleName},
+    {"label": "Run Start Date",
+     "value": RUN_COLS.StartDate},
+    {"label": "Run End Date",
+     "value": RUN_COLS.CompletionDate},
 ]
 
 

--- a/application/dash_application/views/single_lane_rna.py
+++ b/application/dash_application/views/single_lane_rna.py
@@ -145,7 +145,7 @@ def get_rna_data():
                                          util.rnaseqqc2_ius_columns)
 
     # Join RNAseqQc and instrument model
-    rna_df = util.df_with_instrument_model(rna_df, PINERY_COL.SequencerRunName)
+    rna_df = util.df_with_run_info(rna_df, PINERY_COL.SequencerRunName)
 
     return rna_df, util.cache.versions(["rnaseqqc2"])
 
@@ -201,7 +201,11 @@ SORT_BY = sidebar_utils.default_first_sort + [
     {"label": "RIN",
      "value": PINERY_COL.RIN},
     {"label": "Sample Name",
-     "value": PINERY_COL.SampleName}
+     "value": PINERY_COL.SampleName},
+    {"label": "Run Start Date",
+     "value": RUN_COLS.StartDate},
+    {"label": "Run End Date",
+     "value": RUN_COLS.CompletionDate},
 ]
 
 

--- a/application/dash_application/views/single_lane_ts.py
+++ b/application/dash_application/views/single_lane_ts.py
@@ -116,7 +116,7 @@ def get_bamqc_data():
 
     bamqc_df = util.df_with_pinery_samples_ius(bamqc_df, pinery_samples, util.bamqc4_ius_columns)
 
-    bamqc_df = util.df_with_instrument_model(bamqc_df, PINERY_COL.SequencerRunName)
+    bamqc_df = util.df_with_run_info(bamqc_df, PINERY_COL.SequencerRunName)
 
     bamqc_df = util.filter_by_library_design(bamqc_df, util.ex_lib_designs)
 
@@ -181,7 +181,11 @@ SORT_BY = sidebar_utils.default_first_sort + [
     {"label": "Median Insert Size",
      "value": BAMQC_COL.InsertMedian},
     {"label": "Sample Name",
-     "value": PINERY_COL.SampleName}
+     "value": PINERY_COL.SampleName},
+    {"label": "Run Start Date",
+     "value": RUN_COLS.StartDate},
+    {"label": "Run End Date",
+     "value": RUN_COLS.CompletionDate},
 ]
 
 def generate_total_clusters(df, graph_params):

--- a/application/dash_application/views/single_lane_wgs.py
+++ b/application/dash_application/views/single_lane_wgs.py
@@ -173,7 +173,7 @@ def get_wgs_data():
                                          util.bamqc4_ius_columns)
 
     # Join df and instrument model
-    wgs_df = util.df_with_instrument_model(wgs_df, PINERY_COL.SequencerRunName)
+    wgs_df = util.df_with_run_info(wgs_df, PINERY_COL.SequencerRunName)
 
     # Filter the dataframe to only include Illumina data
     illumina_models = util.get_illumina_instruments(wgs_df)
@@ -233,7 +233,11 @@ SORT_BY = sidebar_utils.default_first_sort + [
     {"label": "Median Insert Size",
      "value": BAMQC_COL.InsertMedian},
     {"label": "Sample Name",
-     "value": PINERY_COL.SampleName}
+     "value": PINERY_COL.SampleName},
+    {"label": "Run Start Date",
+     "value": RUN_COLS.StartDate},
+    {"label": "Run End Dat",
+     "value": RUN_COLS.CompletionDate},
 ]
 
 


### PR DESCRIPTION
The start and end date columns were not present, causing silent crash when adding them as data labels. Having added them, ported over the work from #217 to allow for single late date sort.