### PR TITLE
Upgrade ETL to 0.51

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pandas>=1.0.1
 Flask>=1.1.1
 dash==1.13.3
 prometheus_flask_exporter>=0.11.0
-git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v0.47.0
+git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v0.51.0
 sd-material-ui>=3.1.2
 scipy>=1.2.0
 python-dotenv>=0.10.3


### PR DESCRIPTION
Moves Dashi to caches with better type enforcement.