### PR TITLE
Shesmu input link to `status` page to view JSON that's passed to ETL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
+## Added
+  * Shesmu input link to the `status` page to view JSON that's passed to ETL
 
 ## [210412-1508] - 2021-04-12
 ## Changed

--- a/application/templates/status.html
+++ b/application/templates/status.html
@@ -50,12 +50,14 @@
           <th>Cache</th>
           <th>Last Modified</th>
           <th>Errors</th>
+          <th>Shesmu Input</th>
         </tr>
         {% for key, value in errors.items() %}
           <tr>
             <td>{{key}}</td>
             <td>{{lastinputdate[key]}}</td>
             <td><pre><code>{{value}}</code></pre></td>
+            <td><a href="shesmu_input/{{key}}">{{shesmu_input[key]}}</a></td>
           </tr>
         {% endfor %}
       </table>


### PR DESCRIPTION
Page is at http://127.0.0.1:5000/status . This addresses the common issue where we're trying to figure out why a sample isn't it Dashi. This allows one to check what Shesmu has sent to ETL and figure out if it's a Shesmu issue or an ETL/Dashi issue.