### PR TITLE
Use env var to allow getting all Pinery projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Create a `.env` file in the root directory of this repository:
 | `LOG_TO_CONSOLE` | No | Set to log to console as well as to log file specified above | `True` | do not log |
 | `USE_BLEEDING_EDGE_ETL` | No | Set to install `gsi-qc-etl@master` instead of the release version of `gsi-qc-etl` in `requirements.txt` (Docker only) | `1` | use release version |
 | `EXCLUDE_SWAP_LIBS` | No | File path to TSV file of library pairs to be excluded for swap view | `./exclude_swap_lib.tsv` | |
+| `SAMPLES_FOR_PROJECTS` | No | Indicate whether samples from ALL projects should be used, or only samples from ACTIVE projects. | `ALL` | `ACTIVE` |
 
 ## Setup on bare metal
 

--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -1,3 +1,4 @@
+import os
 import pandas
 from pandas import DataFrame, Series
 from typing import List
@@ -370,11 +371,12 @@ def get_rnaseqqc2_merged():
 def get_pinery_samples(active_projects_only=True):
     """Get Pinery Sample Provenance DataFrame"""
     samples = _pinery_samples.copy(deep=True)
-    if (active_projects_only):
+    # Serve samples for active projects unless ALL projects are requested
+    if (not active_projects_only or os.getenv("SAMPLES_FOR_PROJECTS", 'ACTIVE').lower() in ('all')):
+        return samples
+    else:
         return samples.loc[samples[PINERY_COL.StudyTitle].isin(
             _active_projects)]
-    else:
-        return samples
 
 
 def get_pinery_merged_samples(active_projects_only=True):


### PR DESCRIPTION
This keeps "active projects only" as the default, but allows it to be overriden by an environment variable