### PR TITLE
[GR-1309] Add sample hierarchy to swap view + condense view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
+## Changed
+  * Added sample hierarchy information to swap view (hidden by default to avoid clutter)
+  * Made swap view more compact to see all columns on the screen
 
 ## [210914-1010] - 2021-09-14
 ## Changed

--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -181,7 +181,6 @@ _pinery_samples = _pinery_samples.drop(axis=1, columns=[
     PINERY_COL.SequencingParameters,
     PINERY_COL.GroupIDDescription,
     PINERY_COL.CreateDate,
-    PINERY_COL.ParentSampleName,
     PINERY_COL.TemplateType,
     PINERY_COL.RunBaseMask,
     PINERY_COL.RunDir,


### PR DESCRIPTION
Ilinca asked for sample hierarchy information for troubleshooting purposes. To keep table from exploding, new columns are hidden by default (toggle button is fairly obvious and columns are always in the exported spreadsheet). Also edited layout to make the display more compact, so it doesn't require a lot of scrolling to see all columns.