### PR TITLE
[GR-1318] Show all comparisons in swap view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
+## Changed
+  * Add checkbox to swap view to enable seeing all comparisons, not just those marked
+as swaps.
 
 ## [211012-0851] - 2021-10-12
 ## Changed

--- a/application/dash_application/views/sample_swaps.py
+++ b/application/dash_application/views/sample_swaps.py
@@ -212,7 +212,10 @@ for d in TABLE_COLUMNS:
 
 
 # Pair-wise comparison is done within project (for now), so left project is sufficient
-ALL_PROJECTS = df_manipulation.unique_set(swap, PINERY_COL.StudyTitle)
+ALL_PROJECTS = df_manipulation.unique_set(
+    filter_for_swaps(swap),
+    PINERY_COL.StudyTitle
+)
 
 INITIAL = {
     "projects": ALL_PROJECTS,

--- a/application/dash_application/views/sample_swaps.py
+++ b/application/dash_application/views/sample_swaps.py
@@ -30,6 +30,7 @@ ids = init_ids([
 
     # Sidebar
     "all-projects",
+    "checkbox_show_swaps",
     "projects-list",
 
     # Main Table
@@ -146,6 +147,33 @@ def exclude_false_positives(swap_df):
     true_pos = matches["JIRA_ISSUE"].isna()
     return swap_df[list(true_pos)].copy()
 
+
+def filter_for_swaps(df):
+    """
+    Filter for rows that are swaps
+
+    Args:
+        df: The DataFrame must have the been annotated by the `closest_lib` function
+
+    Returns:
+
+    """
+    # Libraries from patients with more than one library
+    # Check for both positive and negative LOD values
+    multi_lib = df[df[special_cols["closest_libraries_count"]] > 1]
+    multi_lib = multi_lib[multi_lib[COL.LODScore].abs() > AMBIGUOUS_ZONE]
+
+    # Libraries from patients with only one library
+    # Negative LOD scores are expected, so only check for positive ones
+    single_lib = df[df[special_cols["closest_libraries_count"]] == 0]
+    single_lib = single_lib[single_lib[COL.LODScore] > AMBIGUOUS_ZONE]
+
+    swaps = pandas.concat([multi_lib, single_lib])
+    swaps = exclude_false_positives(swaps)
+
+    return swaps
+
+
 result = []
 # Two for loops (blah) go through each swap workflow and then check each library
 # Will try to vectorize this if this approach proves superior to previous hard LOD cutoff
@@ -155,19 +183,6 @@ for _, top in swap.groupby(COL.FileSWID):
         result.append(closest_lib(d))
 
 swap = pandas.concat(result)
-
-# Libraries from patients with more than one library
-# Check for both positive and negative LOD values
-multi_lib = swap[swap[special_cols["closest_libraries_count"]] > 1]
-multi_lib = multi_lib[multi_lib[COL.LODScore].abs() > AMBIGUOUS_ZONE]
-
-# Libraries from patients with only one library
-# Negative LOD scores are expected, so only check for positive ones
-single_lib = swap[swap[special_cols["closest_libraries_count"]] == 0]
-single_lib = single_lib[single_lib[COL.LODScore] > AMBIGUOUS_ZONE]
-
-swap = pandas.concat([multi_lib, single_lib])
-swap = exclude_false_positives(swap)
 
 DATA_COLUMN = [
     COL.LibraryLeft,
@@ -227,13 +242,20 @@ def layout(query_string):
                         ALL_PROJECTS,
                         INITIAL["projects"]
                     ),
+                    core.Checklist(
+                        id=ids["checkbox_show_swaps"],
+                        options=[
+                            {"label": "Only show swaps", "value": "swap"},
+                        ],
+                        value=["swap"]
+                    )
                 ]),
                 html.Div(className="seven columns", children=[
                     dash_table.DataTable(
                         id=ids['table'],
                         columns=TABLE_COLUMNS,
                         hidden_columns=DOWNLOAD_ONLY_COLUMNS,
-                        data=swap.to_dict('records'),
+                        data=filter_for_swaps(swap).to_dict('records'),
                         sort_action="native",
                         sort_by=[{"column_id": "LATEST_RUN", "direction": "desc"}],
                         export_format="csv",
@@ -269,10 +291,17 @@ def init_callbacks(dash_app):
     @dash_app.callback(
         Output(ids["table"], "data"),
         [Input(ids["update-button-top"], "n_clicks")],
-        [State(ids['projects-list'], 'value')],
+        [
+            State(ids["projects-list"], "value"),
+            State(ids["checkbox_show_swaps"], "value"),
+        ]
     )
-    def update_pressed(_click, projects):
-        df = swap[swap[PINERY_COL.StudyTitle].isin(projects)]
+    def update_pressed(_click, projects, show_swap):
+        if "swap" in show_swap:
+            df = filter_for_swaps(swap)
+        else:
+            df = swap
+        df = df[df[PINERY_COL.StudyTitle].isin(projects)]
         return df.to_dict('records')
 
     @dash_app.callback(


### PR DESCRIPTION
It is sometimes necessary to see comparisons that were not marked as a
swap. Comparing LOD scores of swaps and non-swaps helps determine false
positives.