### PR TITLE
[GR-1320] Display user messages on individual views.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
+## Changed
+  * User messages can be displayed in each view.
 
 ## [211012-0851] - 2021-10-12
 ## Changed

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Create a `.env` file in the root directory of this repository:
 | `USE_BLEEDING_EDGE_ETL` | No | Set to install `gsi-qc-etl@master` instead of the release version of `gsi-qc-etl` in `requirements.txt` (Docker only) | `1` | use release version |
 | `EXCLUDE_SWAP_LIBS` | No | File path to TSV file of library pairs to be excluded for swap view | `./exclude_swap_lib.tsv` | |
 | `SAMPLES_FOR_PROJECTS` | No | Indicate whether samples from ALL projects should be used, or only samples from ACTIVE projects. | `ALL` | `ACTIVE` |
+| `DISPLAY_USER_MESSAGE` | No | A JSON file containing a dictionary of page names (key) and messages to display (value)| `./user_messages.json` | |
 
 ## Setup on bare metal
 

--- a/application/dash_application/known_pages_router.py
+++ b/application/dash_application/known_pages_router.py
@@ -68,6 +68,13 @@ def navbar(current):
 
 
 def load_user_messages(json_path=os.getenv("DISPLAY_USER_MESSAGE")):
+    """
+    Loads the user messages. Raises an exception in the following cases:
+    * Cannot parse JSON file
+    * If message is not a string
+    * If the view of the message does not exist
+    * If multiple messages exist for a single view
+    """
     if json_path is None:
         return {}
 
@@ -75,9 +82,25 @@ def load_user_messages(json_path=os.getenv("DISPLAY_USER_MESSAGE")):
         logger.warning("User message JSON file does not exist")
         return {}
 
-    # If opening or decoding fails, Dashi will crash.
+    def json_parse(pairs):
+        parsed = {}
+
+        for k, v in pairs:
+            if not isinstance(v, str):
+                raise TypeError("User messages must be a string: {}".format(v))
+
+            if k not in pages_info:
+                raise KeyError("Unknown page name: {}".format(k))
+
+            if k in parsed:
+                raise KeyError("Multiple messages for the same page: {}".format(k))
+            else:
+                parsed[k] = v
+
+        return parsed
+
     with open(json_path, "r") as f:
-        return json.load(f)
+        return json.load(f, object_pairs_hook=json_parse)
 
 
 # Messages to the displayed to users in specific views

--- a/application/dash_application/known_pages_router.py
+++ b/application/dash_application/known_pages_router.py
@@ -100,7 +100,8 @@ layout = html.Div([
     dbc.Alert(
         id="user_message",
         is_open=False,
-        color="warning",
+        color="danger",
+        style={"margin-left": "15px"},
     ),
     core.Loading(id='page-content', type='dot'),
     html.Footer(id='footer', children=[
@@ -161,6 +162,9 @@ def init_callbacks(dash_app):
         """
         If there is a user message associated with the loaded page, display it.
         """
+        if path is None:
+            return "", False
+
         requested = path[1:] # drop the leading slash
         message = user_message.get(requested, None)
         if message is None:

--- a/application/dash_application/known_pages_router.py
+++ b/application/dash_application/known_pages_router.py
@@ -117,7 +117,7 @@ layout = html.Div([
         id="user_message",
         is_open=False,
         color="danger",
-        style={"margin-left": "15px"},
+        style={"margin-left": "15px", "margin-right": "15px"},
     ),
     core.Loading(id='page-content', type='dot'),
     html.Footer(id='footer', children=[

--- a/application/dash_application/known_pages_router.py
+++ b/application/dash_application/known_pages_router.py
@@ -75,16 +75,9 @@ def load_user_messages(json_path=os.getenv("DISPLAY_USER_MESSAGE")):
         logger.warning("User message JSON file does not exist")
         return {}
 
-    # If this fails, it will take down Dashi, so general exception handling is a must
-    try:
-        with open(json_path, "r") as f:
-            return json.load(f)
-    except json.decoder.JSONDecodeError as e:
-        logger.warning("Invalid user message JSON format: {}".format(e))
-        return {}
-    except OSError as e:
-        logger.warning("Failed to open user message JSON file: {}".format(e))
-        return {}
+    # If opening or decoding fails, Dashi will crash.
+    with open(json_path, "r") as f:
+        return json.load(f)
 
 
 # Messages to the displayed to users in specific views

--- a/user_messages.json
+++ b/user_messages.json
@@ -1,0 +1,3 @@
+{
+    "single-lane-rna": "Report is amazing. Just wanted to let you know."
+}


### PR DESCRIPTION
It was not possible to inform users of issues with Dashi without a Dashi
release. This solves the problem by allowing a local JSON file to hold
messages displayed on individual views.