### PR TITLE
[GR-1344] Load sample provenance from disk rather than Mongo DB

### DIFF
--- a/.docker/start.sh
+++ b/.docker/start.sh
@@ -16,6 +16,6 @@ fi
 # mount your private key for bitbucket into the container to allow this command to succeed
 pip install --trusted-host pypi.python.org -r requirements.txt
 
-export MONGO_FILE=/scratch2/groups/gsi/production/qcetl/provenance_samples/latest
+export MONGO_FILE=/cache/provenance_samples/latest
 
 flask run --host=0.0.0.0 --port=5000

--- a/.docker/start.sh
+++ b/.docker/start.sh
@@ -16,6 +16,6 @@ fi
 # mount your private key for bitbucket into the container to allow this command to succeed
 pip install --trusted-host pypi.python.org -r requirements.txt
 
-export MONGO_URL="mongodb://provenance_ro:$(cat /run/secrets/mongo_password)@provenance-mongo-db.gsi.oicr.on.ca:27017/provenance"
+export MONGO_FILE=/scratch2/groups/gsi/production/qcetl/provenance_samples/latest
 
 flask run --host=0.0.0.0 --port=5000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
+## Changed
+  * Sample provenance is loaded from cache on disk rather than Mongo DB
 
 ## [220125-1411] - 2022-01-25
 ## Changed


### PR DESCRIPTION
Couldn't put `MONGO_FILE` in the docker configs on bitbucket. it would conflict with MONGO_URL in `start.sh`. Can't delete MONGO_URL ahead of time, as a Mongo source is mandatory.