### PR TITLE
[GR-1349] Unticking "only show swaps" shows all projects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and as of version 1.0.0, follows semantic versioning.
 ## [Unreleased]
 ## Changed
   * Sample provenance is loaded from cache on disk rather than Mongo DB
+  * Unticking `only show swaps` shows all projects in swap view
+  * Added project name to swap view (does not always match Alias)
+  * Showing meta data along library alias in swap view
 
 ## [220125-1411] - 2022-01-25
 ## Changed

--- a/application/dash_application/views/sample_swaps.py
+++ b/application/dash_application/views/sample_swaps.py
@@ -232,10 +232,7 @@ for d in TABLE_COLUMNS:
 
 
 # Pair-wise comparison is done within project (for now), so left project is sufficient
-ALL_PROJECTS = df_manipulation.unique_set(
-    filter_for_swaps(swap),
-    PINERY_COL.StudyTitle
-)
+ALL_PROJECTS = df_manipulation.unique_set(swap,PINERY_COL.StudyTitle)
 
 INITIAL = {
     "projects": ALL_PROJECTS,
@@ -312,7 +309,7 @@ def layout(query_string):
 
 def init_callbacks(dash_app):
     @dash_app.callback(
-        [Output(ids["table"], "data"), Output(ids["projects-list"], "options")],
+        Output(ids["table"], "data"),
         [Input(ids["update-button-top"], "n_clicks")],
         [
             State(ids["projects-list"], "value"),
@@ -324,10 +321,8 @@ def init_callbacks(dash_app):
             df = filter_for_swaps(swap)
         else:
             df = swap
-        project_options = df_manipulation.unique_set(df, PINERY_COL.StudyTitle)
-        project_options = [{"label":x, "value":x} for x in project_options]
         df = df[df[PINERY_COL.StudyTitle].isin(projects)]
-        return df.to_dict('records'), project_options
+        return df.to_dict('records')
 
     @dash_app.callback(
         Output(ids['projects-list'], 'value'),

--- a/application/dash_application/views/sample_swaps.py
+++ b/application/dash_application/views/sample_swaps.py
@@ -182,8 +182,29 @@ for _, top in swap.groupby(COL.FileSWID):
         result.append(closest_lib(d))
 
 swap = pandas.concat(result)
+swap[COL.LibraryLeft] = (
+     swap[COL.LibraryLeft] +
+     " (" +
+     swap[PINERY_COL.LibrarySourceTemplateType] +
+     ", " +
+     swap[PINERY_COL.TissueType] +
+     ", " +
+     swap[PINERY_COL.TissueOrigin] +
+     ")"
+)
+swap[COL.LibraryRight] = (
+        swap[COL.LibraryRight] +
+        " (" +
+        swap[PINERY_COL.LibrarySourceTemplateType + "_RIGHT"] +
+        ", " +
+        swap[PINERY_COL.TissueType + "_RIGHT"] +
+        ", " +
+        swap[PINERY_COL.TissueOrigin + "_RIGHT"] +
+        ")"
+)
 
 DATA_COLUMN = [
+    PINERY_COL.StudyTitle,
     COL.LibraryLeft,
     COL.LibraryRight,
     COL.LODScore,
@@ -291,7 +312,7 @@ def layout(query_string):
 
 def init_callbacks(dash_app):
     @dash_app.callback(
-        Output(ids["table"], "data"),
+        [Output(ids["table"], "data"), Output(ids["projects-list"], "options")],
         [Input(ids["update-button-top"], "n_clicks")],
         [
             State(ids["projects-list"], "value"),
@@ -303,8 +324,10 @@ def init_callbacks(dash_app):
             df = filter_for_swaps(swap)
         else:
             df = swap
+        project_options = df_manipulation.unique_set(df, PINERY_COL.StudyTitle)
+        project_options = [{"label":x, "value":x} for x in project_options]
         df = df[df[PINERY_COL.StudyTitle].isin(projects)]
-        return df.to_dict('records')
+        return df.to_dict('records'), project_options
 
     @dash_app.callback(
         Output(ids['projects-list'], 'value'),


### PR DESCRIPTION
Unticking "only show swaps" only showed projects that had swaps detected. This was
counter-intuative. Unticking now shows all projects.