### PR TITLE
[GR-1410] The necessary code change for v1.0 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and as of version 1.0.0, follows semantic versioning.
 ## [Unreleased]
 ## Changed
   * Display Shallow Whole Genome libraries
+  * Switch Dashi to qc-etl v1 caches
 
 ## [220418-0952] - 2022-04-18
 ## Changed

--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -158,7 +158,7 @@ if mongo_source.get("MONGO_URL"):
     _provenance_client = pinery.PineryProvenanceClient(provider="pinery-miso-v7")
     _pinery_samples = _provenance_client.get_all_samples()
 elif mongo_source.get("MONGO_FILE"):
-    _pinery_samples = pandas.read_hdf(mongo_source["MONGO_FILE"])
+    _pinery_samples = pinery.load_db("sqlite:///" + mongo_source["MONGO_FILE"])
 else:
     raise ValueError("No Mongo source specified")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pandas>=1.0.1
 Flask>=1.1.1
 dash==1.13.3
 prometheus_flask_exporter>=0.11.0
-git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v0.59.0
+git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v1.1
 sd-material-ui>=3.1.2
 scipy>=1.2.0
 python-dotenv>=0.10.3


### PR DESCRIPTION
Dashi working of qc-etl v1 caches. Note that I'm merging into a dedicated v1 branch, rather then develop. There will be other PRs to take advantage of being not having to load all data into memory at once.

- [X] Updates CHANGELOG.md
- [X] Updates dev docs if applicable
