### PR TITLE
[GP-3542] Remove bamqc3 caches from Dashi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
+## Changed
+  * Remove bamqc3 caches from Dashi
 
 ## [220809-1028] - 2022-08-09
 

--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -14,13 +14,11 @@ rna_lib_designs = ["MR", "SM", "TR", "WT"]
 wgs_lib_designs = ["AS", "CH", "NN", "SW", "WG"]
 
 PINERY_COL = pinery.column.SampleProvenanceColumn
-BAMQC3_COL = gsiqcetl.column.BamQc3Column
 BAMQC4_COL = gsiqcetl.column.BamQc4Column
 CROSSCHECKFINGERPRINTS_COL = gsiqcetl.column.CrosscheckFingerprintsColumn
 DNASEQQC_COL = gsiqcetl.column.DnaSeqQCColumn
 ICHORCNA_COL = gsiqcetl.column.IchorCnaColumn
 RNASEQQC2_COL = gsiqcetl.column.RnaSeqQc2Column
-BAMQC3_MERGED_COL = gsiqcetl.column.BamQc3MergedColumn
 BAMQC4_MERGED_COL = gsiqcetl.column.BamQc4MergedColumn
 ICHORCNA_MERGED_COL = gsiqcetl.column.IchorCnaMergedColumn
 MUTECT_CALL_COL = gsiqcetl.column.MutetctCallabilityColumn
@@ -42,7 +40,6 @@ ml_col = "Merged Library"
 pinery_ius_columns = [PINERY_COL.SequencerRunName, PINERY_COL.LaneNumber,
                       PINERY_COL.IUSTag]
 
-bamqc3_ius_columns = [BAMQC3_COL.Run, BAMQC3_COL.Lane, BAMQC3_COL.Barcodes]
 bamqc4_ius_columns = [BAMQC4_COL.Run, BAMQC4_COL.Lane, BAMQC4_COL.Barcodes]
 dnaseqqc_ius_columns = [DNASEQQC_COL.Run, DNASEQQC_COL.Lane, DNASEQQC_COL.Barcodes]
 ichorcna_ius_columns = [ICHORCNA_COL.Run, ICHORCNA_COL.Lane, ICHORCNA_COL.Barcodes]
@@ -57,9 +54,6 @@ rnaseqqc2_ius_columns = [RNASEQQC2_COL.Run, RNASEQQC2_COL.Lane,
 pinery_merged_columns = [PINERY_COL.StudyTitle, PINERY_COL.RootSampleName,
     PINERY_COL.GroupID, PINERY_COL.LibrarySourceTemplateType,
     PINERY_COL.TissueOrigin, PINERY_COL.TissueType]
-bamqc3_merged_columns = [BAMQC3_MERGED_COL.Project, BAMQC3_MERGED_COL.Donor,
-    BAMQC3_MERGED_COL.GroupID, BAMQC3_MERGED_COL.LibraryDesign,
-    BAMQC3_MERGED_COL.TissueOrigin, BAMQC3_MERGED_COL.TissueType]
 bamqc4_merged_columns = [BAMQC4_MERGED_COL.Project, BAMQC4_MERGED_COL.Donor,
                          BAMQC4_MERGED_COL.GroupID, BAMQC4_MERGED_COL.LibraryDesign,
                          BAMQC4_MERGED_COL.TissueOrigin, BAMQC4_MERGED_COL.TissueType]
@@ -279,18 +273,6 @@ def get_bcl2barcode_run_summary():
     return cache.bcl2barcode.run_summary.copy(deep=True)
 
 
-def get_bamqc3():
-    return normalized_ius(cache.bamqc3.bamqc3, bamqc3_ius_columns)
-
-
-def get_bamqc3_and_4():
-    # Utility function creates new DataFrame, so no need to copy again
-    return gsiqcetl.common.utility.concat_workflow_versions(
-        [normalized_ius(cache.bamqc4.bamqc4, bamqc4_ius_columns), get_bamqc3()],
-        bamqc4_ius_columns,
-    )
-
-
 def get_dnaseqqc_and_bamqc4():
     # Utility function creates new DataFrame, so no need to copy again
     return gsiqcetl.common.utility.concat_workflow_versions(
@@ -355,19 +337,8 @@ def get_runscanner_flowcell():
     return cache.runscannerillumina.flowcell.copy(deep=True)
 
 
-def get_bamqc3_merged():
-    return normalized_merged(cache.bamqc3merged.bamqc3merged, bamqc3_merged_columns)
-
-
-def get_bamqc3_and_4_merged():
-    # Utility function creates new DataFrame, so no need to copy again
-    return gsiqcetl.common.utility.concat_workflow_versions(
-        [
-            normalized_merged(cache.bamqc4merged.bamqc4merged, bamqc4_merged_columns),
-            get_bamqc3_merged()
-        ],
-        bamqc4_merged_columns,
-    )
+def get_bamqc4_merged():
+    return normalized_merged(cache.bamqc4merged.bamqc4merged, bamqc4_merged_columns)
 
 
 def get_ichorcna_merged():

--- a/application/dash_application/views/call_ready_tar.py
+++ b/application/dash_application/views/call_ready_tar.py
@@ -76,7 +76,7 @@ special_cols = {
     "Purity": "Purity",
     "File SWID ichorCNA": "File SWID ichorCNA",
     "File SWID MutectCallability": "File SWID MutectCallability",
-    "File SWID BamQC3": "File SWID BamQC3",
+    "File SWID BamQC": "File SWID BamQC",
     "File SWID HsMetrics": "File SWID HsMetrics",
     "On Target Percentage": "On Target Percentage",
     "Total Clusters (Passed Filter)": "Total Clusters",
@@ -107,17 +107,17 @@ def get_merged_ts_data():
     callability_df = util.get_mutect_callability()
     callability_df = util.filter_by_library_design(callability_df, util.ex_lib_designs, CALL_COL.LibraryDesign)
 
-    bamqc3_df = util.get_bamqc3_and_4_merged()
-    bamqc3_df = util.filter_by_library_design(bamqc3_df, util.ex_lib_designs, BAMQC_COL.LibraryDesign)
+    bamqc4_df = util.get_bamqc4_merged()
+    bamqc4_df = util.filter_by_library_design(bamqc4_df, util.ex_lib_designs, BAMQC_COL.LibraryDesign)
 
-    bamqc3_df[special_cols["Total Reads (Passed Filter)"]] = round(
-        bamqc3_df[BAMQC_COL.TotalReads] / 1e6, 3)
-    bamqc3_df[special_cols["Total Clusters (Passed Filter)"]] = round(
-        bamqc3_df[BAMQC_COL.TotalClusters] / 1e6, 3)
-    bamqc3_df[special_cols["Coverage per Gb"]] = round(
-        bamqc3_df[BAMQC_COL.CoverageDeduplicated] / (
-                bamqc3_df[BAMQC_COL.TotalReads] *
-                bamqc3_df[BAMQC_COL.AverageReadLength] /
+    bamqc4_df[special_cols["Total Reads (Passed Filter)"]] = round(
+        bamqc4_df[BAMQC_COL.TotalReads] / 1e6, 3)
+    bamqc4_df[special_cols["Total Clusters (Passed Filter)"]] = round(
+        bamqc4_df[BAMQC_COL.TotalClusters] / 1e6, 3)
+    bamqc4_df[special_cols["Coverage per Gb"]] = round(
+        bamqc4_df[BAMQC_COL.CoverageDeduplicated] / (
+                bamqc4_df[BAMQC_COL.TotalReads] *
+                bamqc4_df[BAMQC_COL.AverageReadLength] /
                 1e9
         ), 3)
     ichorcna_df[special_cols["Purity"]] = round(
@@ -128,7 +128,7 @@ def get_merged_ts_data():
 
     ichorcna_df.rename(columns={ICHOR_COL.FileSWID: special_cols["File SWID ichorCNA"]}, inplace=True)
     callability_df.rename(columns={CALL_COL.FileSWID: special_cols["File SWID MutectCallability"]}, inplace=True)
-    bamqc3_df.rename(columns={BAMQC_COL.FileSWID: special_cols["File SWID BamQC3"]}, inplace=True)
+    bamqc4_df.rename(columns={BAMQC_COL.FileSWID: special_cols["File SWID BamQC"]}, inplace=True)
     hsmetrics_df.rename(columns={HSMETRICS_COL.FileSWID: special_cols["File SWID HsMetrics"]}, inplace=True)
 
     # Join IchorCNA and HSMetrics Data
@@ -147,23 +147,23 @@ def get_merged_ts_data():
         right_on=util.callability_merged_columns,
         suffixes=('', '_y'))
 
-    # Join BamQC3 and QC data
+    # Join BamQC and QC data
     ts_df = ts_df.merge(
-        bamqc3_df,
+        bamqc4_df,
         how="outer",
         left_on=util.ichorcna_merged_columns,
-        right_on=util.bamqc3_merged_columns,
+        right_on=util.bamqc4_merged_columns,
         suffixes=('', '_z'))
 
     # Join QC data and Pinery data
-    ts_df = util.df_with_pinery_samples_merged(ts_df, pinery_samples, util.bamqc3_merged_columns)
+    ts_df = util.df_with_pinery_samples_merged(ts_df, pinery_samples, util.bamqc4_merged_columns)
 
     ts_df = util.remove_suffixed_columns(ts_df, '_q')  # Pinery duplicate columns
     ts_df = util.remove_suffixed_columns(ts_df, '_x')  # IchorCNA duplicate columns
     ts_df = util.remove_suffixed_columns(ts_df, '_y')  # Callability duplicate columns
-    ts_df = util.remove_suffixed_columns(ts_df, '_z')  # BamQC3 duplicate columns
+    ts_df = util.remove_suffixed_columns(ts_df, '_z')  # BamQC duplicate columns
 
-    return ts_df, util.cache.versions(["bamqc3merged", "ichorcnamerged", "mutectcallability", "hsmetrics"])
+    return ts_df, util.cache.versions(["bamqc4merged", "ichorcnamerged", "mutectcallability", "hsmetrics"])
 
 
 (TS_DF, DATAVERSION) = get_merged_ts_data()

--- a/application/dash_application/views/call_ready_wgs.py
+++ b/application/dash_application/views/call_ready_wgs.py
@@ -76,7 +76,7 @@ special_cols = {
     "Coverage per Gb": "coverage per gb",
     "Percent Callability": "percent callability",
     "File SWID MutectCallability": "File SWID MutectCallability",
-    "File SWID BamQC3": "File SWID BamQC3",
+    "File SWID BamQC": "File SWID BamQC",
     "Tumor Purity (%)": "tumor purity percentage",
     "Total Clusters (Passed Filter)": "Total Clusters",
 }
@@ -100,7 +100,7 @@ def get_merged_wgs_data():
     callability_df = util.filter_by_library_design(callability_df,
                                                    util.wgs_lib_designs,
                                                    CALL_COL.LibraryDesign)
-    bamqc3_df = util.get_bamqc3_and_4_merged()
+    bamqc4_df = util.get_bamqc4_merged()
 
     ichorcna_df = util.get_ichorcna_merged()
     ichorcna_df = ichorcna_df[
@@ -112,39 +112,39 @@ def get_merged_wgs_data():
 
     callability_df[special_cols["Percent Callability"]] = round(
         callability_df[CALL_COL.Callability] * 100.0, 3)
-    bamqc3_df[special_cols["Total Reads (Passed Filter)"]] = round(
-        bamqc3_df[BAMQC_COL.TotalReads] / 1e6, 3)
-    bamqc3_df[special_cols["Total Clusters (Passed Filter)"]] = round(
-        bamqc3_df[BAMQC_COL.TotalClusters] / 1e6, 3)
-    bamqc3_df[special_cols["Coverage per Gb"]] = round(
-        bamqc3_df[BAMQC_COL.CoverageDeduplicated] / (bamqc3_df[
-                 BAMQC_COL.TotalReads] *  bamqc3_df[
+    bamqc4_df[special_cols["Total Reads (Passed Filter)"]] = round(
+        bamqc4_df[BAMQC_COL.TotalReads] / 1e6, 3)
+    bamqc4_df[special_cols["Total Clusters (Passed Filter)"]] = round(
+        bamqc4_df[BAMQC_COL.TotalClusters] / 1e6, 3)
+    bamqc4_df[special_cols["Coverage per Gb"]] = round(
+        bamqc4_df[BAMQC_COL.CoverageDeduplicated] / (bamqc4_df[
+                 BAMQC_COL.TotalReads] *  bamqc4_df[
                  BAMQC_COL.AverageReadLength] / 1e9), 3)
     callability_df.rename(columns={
         CALL_COL.FileSWID: special_cols["File SWID MutectCallability"]},
                           inplace=True)
-    bamqc3_df.rename(
-        columns={BAMQC_COL.FileSWID: special_cols["File SWID BamQC3"]},
+    bamqc4_df.rename(
+        columns={BAMQC_COL.FileSWID: special_cols["File SWID BamQC"]},
         inplace=True)
 
-    # Join BamQC3 and Callability data
-    wgs_df = bamqc3_df.merge(
+    # Join BamQC and Callability data
+    wgs_df = bamqc4_df.merge(
         callability_df,
         how="left",
-        left_on=util.bamqc3_merged_columns,
+        left_on=util.bamqc4_merged_columns,
         right_on=util.callability_merged_columns,
         suffixes=('', '_x')
     )
 
     # Join QC data and Pinery data
     wgs_df = util.df_with_pinery_samples_merged(wgs_df, pinery_samples,
-                                                util.bamqc3_merged_columns)
+                                                util.bamqc4_merged_columns)
 
     # Join in ichorcna data
     wgs_df = wgs_df.merge(
         ichorcna_df,
         how="left",
-        left_on=util.bamqc3_merged_columns,
+        left_on=util.bamqc4_merged_columns,
         right_on=util.ichorcna_merged_columns,
         suffixes=('', '_i')
     )
@@ -154,7 +154,7 @@ def get_merged_wgs_data():
     wgs_df = util.remove_suffixed_columns(wgs_df, '_i')  # Ichorcna duplicate columns
 
     return wgs_df, util.cache.versions(
-        ["mutectcallability", "bamqc3merged"])
+        ["mutectcallability", "bamqc4merged"])
 
 
 # Make the WGS dataframe


### PR DESCRIPTION
Fun fact. bamqc3 caches don't exist anymore, as I mistakenly thought Dashi didn't depend on them. What saved Dashi was the rsync script that does not delete files that no longer exist at source.

Jira ticket or GitHub issue:

- [x] Updates CHANGELOG.md
- [x] Updates dev docs if applicable
