### PR TITLE
Switch to gsi-qc-etl v1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and as of version 1.0.0, follows semantic versioning.
   * Switch Dashi to qc-etl v1 caches
   * Update Python Docker version to 3.10
   * Swap view no longer loads huge data into memory and does heavy computation. Done by qc-etl.
+  * Use gsi-qc-etl v1.9, which uses a Pandas version supported by Python 3.10
 
 ## [221003-0956] - 2022-10-03
 ## Changed

--- a/application/dash_application/views/bcl2barcode.py
+++ b/application/dash_application/views/bcl2barcode.py
@@ -136,7 +136,7 @@ PINERY_COL = util.PINERY_COL
 # This needs to match what is set during de-multiplexing
 BCL2FASTQ_MISMATCH = 1
 
-barcode_expansions = pandas.read_csv(os.getenv("BARCODES_STREXPAND"), sep="\t", header=None).melt(id_vars=0).drop(labels="variable", axis="columns").set_axis(['Index', 'Sequence'], axis="columns", inplace=False)
+barcode_expansions = pandas.read_csv(os.getenv("BARCODES_STREXPAND"), sep="\t", header=None).melt(id_vars=0).drop(labels="variable", axis="columns").set_axis(['Index', 'Sequence'], axis="columns", copy=False)
 # Expand pinery to include 4 rows for every 1 10X barcode
 # This allows for merging with the nucleotide sequence in bcl2barcode
 pinery_with_expanded_barcodes = pandas.merge(pinery, barcode_expansions, left_on='iusTag', right_on='Index', how='left')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 Flask_Caching>=1.7.2
 dash_bootstrap_components==0.7.2
-pandas>=1.0.1
+pandas>=1.4.0
 Flask>=1.1.1
 dash==1.13.3
 prometheus_flask_exporter>=0.11.0
-git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v1.8
+git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v1.9
 sd-material-ui>=3.1.2
 scipy>=1.2.0
 python-dotenv>=0.10.3


### PR DESCRIPTION
There were older Pandas dependencies in gsi-qc-etl that don't have a pre-built wheel for Python 3.10. As the Docker image always rebuilds all packages, this adds ~7 min to the start-up time. Update to a newer Pandas version to remove that slowness.

Jira ticket or GitHub issue:

- [X ] Updates CHANGELOG.md
- [ X] Updates dev docs if applicable
