### PR TITLE
[GR-1462] Fix bug that excluded whole projects from swap view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
+  * Fix bug where libraries without swaps were completely excluded from swap view
 
 ## [221017-1015] - 2022-10-17
   * Switch Dashi to qc-etl v1 caches


### PR DESCRIPTION
Non-swapped libraries were excluded, which meant that projects without swaps weren't in Dashi and showing all libraries did not work correctly.

Jira ticket or GitHub issue:

- [X] Updates CHANGELOG.md
- [X] Updates dev docs if applicable
