### PR TITLE
[GR-1491] Join Merged Pinery LIMS ID as string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
+  * Fixed Merged Pinery Lims ID being blank in exported csv
 
 ## [230303-1532] - 2023-03-03
   * Removed SARS-CoV-2 view

--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -115,6 +115,8 @@ def normalized_ius(df: DataFrame, ius_cols: List[str]):
 
 def normalized_merged(df: DataFrame, merged_cols: List[str]):
     project_col, donor_col, group_id_col, ld_col, to_col, tt_col = merged_cols
+    if 'Merged Pinery Lims ID' in df.columns:
+        df['Merged Pinery Lims ID'] = df['Merged Pinery Lims ID'].apply(','.join)
     return df.astype({
         project_col: 'str',
         donor_col: 'str',


### PR DESCRIPTION
Jira ticket or GitHub issue: GR-1491

Prevents poorly concatenated display in front end, missing column on the exported spreadsheet 

- [x] Updates CHANGELOG.md
- [n/a] Updates dev docs if applicable
