### PR TITLE
Reverted to rnaseqqc2 V2 cache due to column naming bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
+  * Reverted to rnaseqqc2 V2 cache due to column naming bug
 
 ## [230330-1200] - 
   * Fixed Merged Pinery Lims ID being blank in exported csv

--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -6,6 +6,7 @@ from typing import List
 from gsiqcetl import QCETLCache
 import gsiqcetl.column
 import gsiqcetl.common.utility
+import gsiqcetl.common
 import pinery
 import json
 
@@ -300,7 +301,8 @@ def get_ichorcna():
 
 
 def get_rnaseqqc2():
-    return normalized_ius(cache.rnaseqqc2.rnaseqqc2, rnaseqqc2_ius_columns)
+    # TODO: Temporary loading older cache due to bug. Revert after fix.
+    return normalized_ius(cache.load("rnaseqqc2", 2, gsiqcetl.common.CleaningRules(), lambda x: None).rnaseqqc2, rnaseqqc2_ius_columns)
 
 
 def get_runscanner_flowcell():


### PR DESCRIPTION
Jira ticket or GitHub issue:

- [X] Updates CHANGELOG.md
- [X] Updates dev docs if applicable
