### PR TITLE
Narrow Flask version to speed up Docker installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
   * Yet more columns for the All Samples tables
+  * Narrow Flask version to speed up Docker installation
 
 ## [230503-1624] - 2023-05-03
   * Remove all ichorcna usage.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask-Caching~=2.0
 dash-bootstrap-components~=1.4
 pandas~=1.5
-Flask~=2.0
+Flask~=2.0.0
 dash~=2.8
 prometheus-flask-exporter~=0.22
 gsiqcetl @ git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v1.23


### PR DESCRIPTION
The change does not change which version of Flask gets installed (Flask-2.0.3), but removes all `INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime` warning messages.

Jira ticket or GitHub issue:

- [X] Updates CHANGELOG.md
- [X] Updates dev docs if applicable
