### PR TITLE
Removed unnecessary Docker instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and as of version 1.0.0, follows semantic versioning.
 ## [Unreleased]
   * Yet more columns for the All Samples tables
   * Narrow Flask version to speed up Docker installation
+  * Removed unnecessary Docker instructions
 
 ## [230503-1624] - 2023-05-03
   * Remove all ichorcna usage.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,8 @@ WORKDIR /dashi
 # the cache or Dockerfile
 COPY *.py requirements.txt /dashi/
 
-# Requirements for pytables (HDF5) and scipy (blas and la and fortran) and expect for passing a passphrase to ssh-agent
-RUN apt-get -yy update && apt-get -yy install libhdf5-serial-dev libblas3 liblapack3 liblapack-dev libblas-dev gfortran expect
-RUN pip install --trusted-host pypi.python.org $(awk '!/git\+ssh.*/' requirements.txt)
+# Requirements for expect for passing a passphrase to ssh-agent
+RUN apt-get -yy update && apt-get -yy install expect
 
 COPY application /dashi/application/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ dash~=2.8
 prometheus-flask-exporter~=0.22
 gsiqcetl @ git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v1.23
 sd-material-ui~=4.6
-scipy~=1.10
 python-dotenv~=0.19
 gevent~=22.10
 gunicorn~=20.1


### PR DESCRIPTION
HDF5 and scipy are no longer used. `pip install` was being run twice: once in Dockerfile and then in `start.sh`.

Jira ticket or GitHub issue:

- [X] Updates CHANGELOG.md
- [X] Updates dev docs if applicable
