### PR TITLE
Update gsiqcetl to V1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
   * Yet more columns for the All Samples tables
-  * Narrow Flask version to speed up Docker installation
   * Removed unnecessary Docker instructions
+  * Update gsiqcetl to V1.24, which allows for Flask to be updated to latest version
+    (removes `click` dependency conflict)
 
 ## [230503-1624] - 2023-05-03
   * Remove all ichorcna usage.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 Flask-Caching~=2.0
 dash-bootstrap-components~=1.4
 pandas~=1.5
-Flask~=2.0.0
+Flask~=2.3
 dash~=2.8
 prometheus-flask-exporter~=0.22
-gsiqcetl @ git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v1.23
+gsiqcetl @ git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v1.24
 sd-material-ui~=4.6
 python-dotenv~=0.19
 gevent~=22.10


### PR DESCRIPTION
Fixing Flask version to 2.0.0 removed long dependancy resolution, but that version was flagged with security risks. `crimson` package in gsi-qc-etl had to be updated, as it (via the `click` dependancy) was preventing the newest version of Flask being used. Newest version does not have dependancy resolution issues.

Jira ticket or GitHub issue:

- [x] Updates CHANGELOG.md
- [x] Updates dev docs if applicable
