### PR TITLE
Fixed deprecated `DataFrame.max` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
   * Add comments to requirements.txt to explain `~=` operator
+  * Fixed deprecated `DataFrame.max` parameter
 
 ## [230717-1358] - 2023-07-17
   * One more column for the All Samples table: Coverage for single lane TAR

--- a/application/dash_application/views/sample_swaps.py
+++ b/application/dash_application/views/sample_swaps.py
@@ -98,7 +98,7 @@ if len(swap) > 0:
     # Get the latest run of the pair for sorting purposes and make format YYYY-MM-DD
     swap[special_cols["latest_run"]] = swap[
         [RUN_COLS.StartDate, RUN_COLS.StartDate + "_MATCH"]
-    ].max(1).dt.date
+    ].max(1, numeric_only=False).dt.date
     swap[special_cols["same_identity"]] = (
         swap[PINERY_COL.RootSampleName] == swap[PINERY_COL.RootSampleName + "_MATCH"]
     )


### PR DESCRIPTION
This bug is very strange and I don't entirely understand it. Dashi uses Pandas 1.5.0 on stage and production. Stage Dashi crashes with gsi-qc-etl v1.27 cache, but works fine with v1.26. The crash happens because the `max` call works differently between the two caches. I don't understand why it is working differently. The type of the two columns passed to `max` stays the same between the two cache versions. Why would I get a parameter deprecation warning using Pandas 1.5.0 on one cache, but not a deprecation version using Pandas 1.5.0 on another cache?

Either way, fixing the deprecation warning fixes the issue.

- [x] Updates CHANGELOG.md
- [x] Updates dev docs if applicable
