### PR TITLE
Bump gsi-qc-etl to v1.27, which fixes the PyYAML bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and as of version 1.0.0, follows semantic versioning.
 ## [Unreleased]
   * Add comments to requirements.txt to explain `~=` operator
   * Fixed deprecated `DataFrame.max` parameter
+  * Bumped gsi-qc-etl version to 1.27 and removed temporary PyYAML version fix
 
 ## [230717-1358] - 2023-07-17
   * One more column for the All Samples table: Coverage for single lane TAR

--- a/application/dash_application/views/call_ready_rna.py
+++ b/application/dash_application/views/call_ready_rna.py
@@ -53,7 +53,7 @@ ids = init_ids([
     'all-count',
 ])
 
-RNASEQQC2_COL = gsiqcetl.column.RnaSeqQc2V3MergedColumn
+RNASEQQC2_COL = gsiqcetl.column.RnaSeqQc2MergedColumn
 PINERY_COL = pinery.column.SampleProvenanceColumn
 
 

--- a/application/dash_application/views/single_lane_rna.py
+++ b/application/dash_application/views/single_lane_rna.py
@@ -9,7 +9,7 @@ from ..utility.table_builder import table_tabs_single_lane, cutoff_table_data_iu
 from ..utility import df_manipulation as util
 from ..utility import sidebar_utils
 from ..utility import log_utils
-from gsiqcetl.column import RnaSeqQc2V3Column as RnaColumn
+from gsiqcetl.column import RnaSeqQc2Column as RnaColumn
 import pinery
 import logging
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,11 @@ pandas~=1.5
 Flask~=2.3
 dash~=2.8
 prometheus-flask-exporter~=0.22
-gsiqcetl @ git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v1.25
+gsiqcetl @ git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v1.27
 sd-material-ui~=4.6
 python-dotenv~=0.19
 gevent~=22.10
 gunicorn~=20.1
 numpy~=1.23
 Werkzeug~=2.2
-pyyaml==5.3.1 # required because of pyyaml bug https://github.com/yaml/pyyaml/issues/601
 


### PR DESCRIPTION
RNASeq columns were deprecated in v1.27 and have been changed as well.

- [x] Updates CHANGELOG.md
- [x] Updates dev docs if applicable
