### PR TITLE
A kludge for crosscheckfingerprints because qc-etl couldn't do its job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
+  * Insert a annoying kludge because gsi-qc-etl does not handle crosscheckfingerprints correctly
 
 ## [231016-1108] - 2023-10-16
   * Bump gevent version due to security issue

--- a/application/dash_application/utility/df_manipulation.py
+++ b/application/dash_application/utility/df_manipulation.py
@@ -3,7 +3,7 @@ import pandas
 from pandas import DataFrame, Series
 from typing import List
 
-from gsiqcetl import QCETLMultiCache
+from gsiqcetl import QCETLMultiCache, QCETLCache
 import gsiqcetl.column
 import gsiqcetl.common.utility
 import gsiqcetl.common
@@ -292,12 +292,20 @@ def get_cfmedip_insert_metrics():
 
 
 def get_crosscheckfingerprints():
+    # qc-etl couldn't gracefully switch versions, so Dashi has to pay the temporary price
+    kludge_cache = QCETLCache(root_dirs[0])
+    try:
+        return kludge_cache.load("crosscheckfingerprints", 3).filterswaps
+    except ValueError:
+        return kludge_cache.load("crosscheckfingerprints", 4).filterswaps
+    """
     return cache.load_same_version(
         "crosscheckfingerprints"
     # crosscheckfingerprints caches won't be archived
     ).remove_missing(
         "filterswaps"
     ).unique("filterswaps").copy(deep=True)
+    """
 
 
 def get_fastqc():


### PR DESCRIPTION
Usually qc-etl keeps two versions around to make migratio invisible to Dashi. With crosscheckfingerprints, that wasn't possible because the long cache times are causing Shesmu instability. Having two versions of caches in there would have probably made the instability a lot worse. This means that Dashi has to deal with picking the right version. This is temporary. Once the caches are all switched to the new version, this can be removed.

Jira ticket or GitHub issue:

- [x] Updates CHANGELOG.md
- [x] Updates dev docs if applicable
