### PR TITLE
Update gsi-qc-etl, which has had version bumps that Dashi now mirrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and as of version 1.0.0, follows semantic versioning.
 ## [Unreleased]
   * Replace Pandas `NaN` with Python `None`. When sending to MISO, `None` gets converted to `null`, which is what MISO
 expects.
+  * Updated requirements.txt with newest gsi-qc-etl version, which required other version to be bumped
+  * Updated gunicorn version for security
 
 ## [240930-1516] - 2024-09-30
   * Fix MISO URL formatting for MISO 2.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
 # The `~=` is the compatible release operator (https://peps.python.org/pep-0440/#compatible-release)
 Flask-Caching~=2.0
 dash-bootstrap-components~=1.4
-pandas~=1.5
+pandas~=2.2
 Flask~=2.3
 dash~=2.18
 prometheus-flask-exporter~=0.22
-gsiqcetl @ git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v1.28
+gsiqcetl @ git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v1.33
 sd-material-ui~=4.6
-python-dotenv~=0.19
+python-dotenv~=1.1
 gevent~=23.9
-gunicorn~=20.1
-numpy~=1.23
+gunicorn~=23.0
+numpy~=2.2
 Werkzeug~=3.0
 


### PR DESCRIPTION
Updated gunicorn to appease dependabot

Jira ticket or GitHub issue:

- [x] Updates CHANGELOG.md
- [x] Updates dev docs if applicable
