### PR TITLE
GP-5476: Update dashi Dockerfile to use python:3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and as of version 1.0.0, follows semantic versioning.
 
 ## [Unreleased]
 
+  * Upgrade Python to 3.13
+
 ## [260528-1518] - 2026-05-28
   * Upgrade Flask to 3.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.13
 
 USER root
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ prometheus-flask-exporter~=0.22
 gsiqcetl @ git+ssh://git@bitbucket.oicr.on.ca/gsi/gsi-qc-etl.git@v1.47
 sd-material-ui~=4.6
 python-dotenv~=1.1
-gevent~=23.9
+gevent~=26.5
 gunicorn~=23.0
 numpy~=2.2
 Werkzeug~=3.1


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GP-5476

Updates the Dashi base image from python:3.10 to python:3.13. Also updated gevent because it was failing to install the requirements with the old version.

- [x] Updates CHANGELOG.md
- [ ] Updates dev docs if applicable
